### PR TITLE
chore: sync @reddoorla/maintenance configs (0.5.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ test-results
 # OS / editor
 .DS_Store
 .vscode
+
+# canonical entries from @reddoorla/maintenance sync-configs
+coverage/
+.vitest-cache/
+.tsbuildinfo
+*.log
+.vercel/

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typescript": "^5.5.0",
     "typescript-svelte-plugin": "^0.3.36",
     "vite": "^6.0.7",
-    "@reddoorla/maintenance": "^0.2.0",
+    "@reddoorla/maintenance": "^0.5.0",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.59.1",
     "@axe-core/playwright": "^4.11.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^1.59.1
         version: 1.60.0
       '@reddoorla/maintenance':
-        specifier: ^0.2.0
-        version: 0.2.0(jiti@1.21.7)(playwright-core@1.60.0)(svelte@5.55.9(@typescript-eslint/types@8.59.4))(typescript@5.9.3)
+        specifier: ^0.5.0
+        version: 0.5.0(jiti@1.21.7)(playwright-core@1.60.0)(svelte@5.55.9(@typescript-eslint/types@8.59.4))(typescript@5.9.3)
       '@slicemachine/adapter-sveltekit':
         specifier: ^0.3.36
         version: 0.3.96(@prismicio/types@0.2.9)(@sveltejs/kit@2.60.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.9(@typescript-eslint/types@8.59.4))(vite@6.4.2(@types/node@25.9.1)(jiti@1.21.7)))(svelte@5.55.9(@typescript-eslint/types@8.59.4))(typescript@5.9.3)(vite@6.4.2(@types/node@25.9.1)(jiti@1.21.7)))(prettier-plugin-svelte@3.5.2(prettier@3.8.3)(svelte@5.55.9(@typescript-eslint/types@8.59.4)))(prettier@3.8.3)(svelte@5.55.9(@typescript-eslint/types@8.59.4))
@@ -657,8 +657,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@reddoorla/maintenance@0.2.0':
-    resolution: {integrity: sha512-k8cCrfle99mLqE3LvMD7l1cDdGU8Ao+v67qmWB6vGreUg2Cidu7pgA6B9bOPymWlpwpB4P84dIeWEmMhxhvaIg==}
+  '@reddoorla/maintenance@0.5.0':
+    resolution: {integrity: sha512-cUb3YbTvVFKCzZ99QKw4ZSWgpx8yypxDrwtOrJ/nFneWHY/NTSK0o/NRUbNguofwD+rcxLER2neUsB8ofz1mBg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -4021,7 +4021,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@reddoorla/maintenance@0.2.0(jiti@1.21.7)(playwright-core@1.60.0)(svelte@5.55.9(@typescript-eslint/types@8.59.4))(typescript@5.9.3)':
+  '@reddoorla/maintenance@0.5.0(jiti@1.21.7)(playwright-core@1.60.0)(svelte@5.55.9(@typescript-eslint/types@8.59.4))(typescript@5.9.3)':
     dependencies:
       '@axe-core/playwright': 4.11.3(playwright-core@1.60.0)
       '@eslint/js': 10.0.1(eslint@10.4.0(jiti@1.21.7))

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,15 +1,7 @@
-import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { createSvelteConfig } from "@reddoorla/maintenance/configs/svelte";
+import adapter from "@sveltejs/adapter-auto";
 
 /** @type {import('@sveltejs/kit').Config} */
-const config = {
-	kit: {
-		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
-		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter()
-	},
-	preprocess: vitePreprocess(),
-};
-
-export default config;
+export default createSvelteConfig({
+  kit: { adapter: adapter() },
+});


### PR DESCRIPTION
## Summary

Re-syncs caltex against [@reddoorla/maintenance@0.5.0](https://www.npmjs.com/package/@reddoorla/maintenance/v/0.5.0) — picks up the canonical Svelte config helper and the new fleet-wide `.gitignore` management.

## Commits

- **`chore: bump @reddoorla/maintenance to ^0.5.0`** — required to reach forward through the 0.x bumps (caret on `^0.2.0` wouldn't have resolved).
- **`chore: sync svelte config from @reddoorla/maintenance`** — replaces the legacy `svelte.config.js` (raw object + `vitePreprocess`) with the canonical `createSvelteConfig` wrapper. Silences `element_invalid_self_closing_tag` warnings across all `<div ... />`-style components without per-site filter code. Drops `vitePreprocess()` (Svelte 5 no longer needs it).
- **`chore: sync gitignore from @reddoorla/maintenance`** — appends 5 missing canonical entries (`coverage/`, `.vitest-cache/`, `.tsbuildinfo`, `*.log`, `.vercel/`) under a managed marker. Existing site-specific lines (notably `.vscode`) preserved untouched. No tracked artifacts to untrack — already cleaned up in the previous PR.

## Test plan

- [ ] `pnpm install` (lockfile already updated for 0.5.0)
- [ ] `pnpm dev` — confirm dev server starts cleanly, no `element_invalid_self_closing_tag` warnings
- [ ] `pnpm build` — confirm production build works with the new `createSvelteConfig` wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)