### PR TITLE
chore: apply @reddoorla/maintenance 0.6.0 codemods + DefaultButton reactivity fix

### DIFF
--- a/src/lib/components/Animation/AnimateIn.svelte
+++ b/src/lib/components/Animation/AnimateIn.svelte
@@ -1,15 +1,14 @@
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang="ts">
-    import { onDestroy, onMount } from "svelte";
+      let { style = "", transitionDelayMax = 400, transitionDuration = 2400 }: { style?: unknown; transitionDelayMax?: unknown; transitionDuration?: unknown } = $props();
+import { onDestroy, onMount } from "svelte";
   
       let isInView = false;
       let el:HTMLElement | null;
       let transitionDelay = 0;
-      export let style ="";
-  
-      export let transitionDelayMax = 400;
-      export let transitionDuration = 2400;
-  
+
+
+
       const checkViewport = () => {
           if(window&&el){
                   let rect = el.getBoundingClientRect();

--- a/src/lib/components/Buttons/ArrowButton.svelte
+++ b/src/lib/components/Buttons/ArrowButton.svelte
@@ -11,9 +11,9 @@
 </script>
 
 <a 
-on:mouseenter={()=>isLinkArrowActive=true} 
-on:mouseleave={()=>isLinkArrowActive=false}
-on:click= {()=>isLinkArrowActive=false}
+onmouseenter={()=>isLinkArrowActive=true} 
+onmouseleave={()=>isLinkArrowActive=false}
+onclick= {()=>isLinkArrowActive=false}
 class="flex flex-row items-center text-center no-underline justify-center transition-all duration-300 active:-translate-y-2 {$$props.class || ''}" 
 {href}>
     <span class="h-5 uppercase no-underline translate-y-[3.5px]">{text}</span>

--- a/src/lib/components/Buttons/ArrowButton.svelte
+++ b/src/lib/components/Buttons/ArrowButton.svelte
@@ -1,9 +1,6 @@
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script>
-    import linkArrow from "$lib/assets/icons/wireframe-link-arrow-right.svg"
-    export let text = "";
-    export let href ="#"
+      let { text = "", href = "#", class: className = "" } = $props();
+import linkArrow from "$lib/assets/icons/wireframe-link-arrow-right.svg"
 
 
     let isLinkArrowActive=false;
@@ -14,7 +11,7 @@
 onmouseenter={()=>isLinkArrowActive=true} 
 onmouseleave={()=>isLinkArrowActive=false}
 onclick= {()=>isLinkArrowActive=false}
-class="flex flex-row items-center text-center no-underline justify-center transition-all duration-300 active:-translate-y-2 {$$props.class || ''}" 
+class="flex flex-row items-center text-center no-underline justify-center transition-all duration-300 active:-translate-y-2 {className || ''}" 
 {href}>
     <span class="h-5 uppercase no-underline translate-y-[3.5px]">{text}</span>
     <img src={linkArrow} alt="" aria-hidden="true" class="h-5 w-5 -translate-y-[1px] ml-[10px] transition-transform duration-300 {isLinkArrowActive ? "translate-x-2":""}">

--- a/src/lib/components/Buttons/DefaultButton.svelte
+++ b/src/lib/components/Buttons/DefaultButton.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     let { href = "", onclick, class:passedClasses = '', children, isWhite=false, ...others  } = $props();
 
-    let baseClasses = $state("rounded border-2 border-solid border-dark px-10 py-3 flex items-center justify-center h-fit hover:bg-dark hover:text-white transition")
-    if(isWhite)
-        baseClasses="rounded text-white border-2 border-solid border-white px-10 py-3 flex items-center justify-center h-fit hover:bg-white hover:text-dark transition"
+    let baseClasses = $derived(isWhite
+        ? "rounded text-white border-2 border-solid border-white px-10 py-3 flex items-center justify-center h-fit hover:bg-white hover:text-dark transition"
+        : "rounded border-2 border-solid border-dark px-10 py-3 flex items-center justify-center h-fit hover:bg-dark hover:text-white transition")
 
 </script>
 

--- a/src/lib/components/ContentWidth/ContentWidthGallerySlider.svelte
+++ b/src/lib/components/ContentWidth/ContentWidthGallerySlider.svelte
@@ -1,7 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang='ts'>
-      let { imageArray = [placeholder, placeholder, placeholder, placeholder], altText = "background image" }: { imageArray?: unknown; altText?: unknown } = $props();
+      let { imageArray = [placeholder, placeholder, placeholder, placeholder], altText = "background image", class: className = "" }: { imageArray?: unknown; altText?: unknown; class?: string } = $props();
 import { onMount } from "svelte";
     import { swipe } from "svelte-gestures";
     import placeholder from "../../assets/images/background_placeholder.svg";
@@ -71,7 +69,7 @@ import { onMount } from "svelte";
   </script>
   <svelte:window bind:innerWidth={viewportWidth} />
       
-  <section class="pb-32 {$$props.class || ''}">
+  <section class="pb-32 {className || ''}">
       <div use:swipe onswipe={handleSwipe} class="h-[320px] py-2 relative" >
         <div class="overflow-hidden w-screen mt-20 lg:mt-0" style="margin-left:{viewportWidth>1340 ? (viewportWidth-1220/2):viewportWidth*0.04};">
       <div  class="h-full flex flex-row flex-nowrap {isSlideAnimated ? 'transition-transform duration-[2000ms]': ''}"

--- a/src/lib/components/ContentWidth/ContentWidthGallerySlider.svelte
+++ b/src/lib/components/ContentWidth/ContentWidthGallerySlider.svelte
@@ -1,7 +1,8 @@
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang='ts'>
-    import { onMount } from "svelte";
+      let { imageArray = [placeholder, placeholder, placeholder, placeholder], altText = "background image" }: { imageArray?: unknown; altText?: unknown } = $props();
+import { onMount } from "svelte";
     import { swipe } from "svelte-gestures";
     import placeholder from "../../assets/images/background_placeholder.svg";
     import ContentWidth from "../ContentWidth/ContentWidth.svelte";
@@ -9,12 +10,7 @@
     import chevronLeft from "$lib/assets/icons/chevron-left.svg"
     import chevronRight from "$lib/assets/icons/chevron-right.svg"
 
-      
-      export let imageArray = [placeholder, placeholder, placeholder, placeholder];
-      export let altText = "background image"
 
-      
-  
       const SLIDER_TRANSITION_FUNCTION="cubic-bezier(.5,0,0,1)";
       const SLIDER_TRANSITION_LENGTH_IN_MS=2000;
       const SLIDER_INTERVAL_IN_MS = 5000;
@@ -76,7 +72,7 @@
   <svelte:window bind:innerWidth={viewportWidth} />
       
   <section class="pb-32 {$$props.class || ''}">
-      <div use:swipe on:swipe={handleSwipe} class="h-[320px] py-2 relative" >
+      <div use:swipe onswipe={handleSwipe} class="h-[320px] py-2 relative" >
         <div class="overflow-hidden w-screen mt-20 lg:mt-0" style="margin-left:{viewportWidth>1340 ? (viewportWidth-1220/2):viewportWidth*0.04};">
       <div  class="h-full flex flex-row flex-nowrap {isSlideAnimated ? 'transition-transform duration-[2000ms]': ''}"
       style= "width:{352*tripledImages.length}px; margin-left:{viewportWidth>1340 ? (viewportWidth-1220/2):viewportWidth*0.04}; transform:translateX({-(sliderIndex+imageArray.length)*352}px); ">
@@ -95,10 +91,10 @@
         <ContentWidth class="h-full relative w-full">
           
 
-          <button on:click={slideLeft} aria-label="Previous image" class="absolute left-0 lg:top-auto lg:-left-2 h-6 w-6 rounded-full border-[#C2D1D9] border-2 p-1 flex align-middle justify-center cursor-pointer transition-all duration-500 hover:bg-[#424B5A] hover:border-[#424B5A] active:bg-black bump {sliderIndex===0 ? "opacity-20 pointer-events-none":""}">
+          <button onclick={slideLeft} aria-label="Previous image" class="absolute left-0 lg:top-auto lg:-left-2 h-6 w-6 rounded-full border-[#C2D1D9] border-2 p-1 flex align-middle justify-center cursor-pointer transition-all duration-500 hover:bg-[#424B5A] hover:border-[#424B5A] active:bg-black bump {sliderIndex===0 ? "opacity-20 pointer-events-none":""}">
             <img alt='' aria-hidden="true" src={chevronLeft} class='-translate-x-[1px]' />
           </button>
-          <button on:click={slideRight} aria-label="Next image" class="absolute right-0 lg:right-auto lg:-left-2 lg:top-12  -translate-y-[0.7px] h-6 w-6 rounded-full border-[#C2D1D9] border-2 p-1 flex align-middle cursor-pointer transition-all duration-500 justify-center hover:bg-[#424B5A] hover:border-[#424B5A] active:bg-black bump {sliderIndex===imageArray.length-1 ? "opacity-20 pointer-events-none":""}">
+          <button onclick={slideRight} aria-label="Next image" class="absolute right-0 lg:right-auto lg:-left-2 lg:top-12  -translate-y-[0.7px] h-6 w-6 rounded-full border-[#C2D1D9] border-2 p-1 flex align-middle cursor-pointer transition-all duration-500 justify-center hover:bg-[#424B5A] hover:border-[#424B5A] active:bg-black bump {sliderIndex===imageArray.length-1 ? "opacity-20 pointer-events-none":""}">
             <img alt='' aria-hidden="true" src={chevronRight} class='translate-x-[1px] ' />
           </button>
         </ContentWidth>

--- a/src/lib/components/FullWidth/ContentBox.svelte
+++ b/src/lib/components/FullWidth/ContentBox.svelte
@@ -1,24 +1,21 @@
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang='ts'>
-    import placeholderIcon from "../../assets/icons/logos/logo.svg"
+      let { icon = "", iconAltText = "logo", labelText = "", titleText = "", titleTag = "h3", subtitleText = "", paragraphText = "", buttonText = "", linkText = "", linkHref = "", backgroundColor = "transparent", float = "center" }: { icon?: unknown; iconAltText?: unknown; labelText?: unknown; titleText?: unknown; titleTag?: unknown; subtitleText?: unknown; paragraphText?: unknown; buttonText?: unknown; linkText?: unknown; linkHref?: unknown; backgroundColor?: unknown; float?: unknown } = $props();
+import placeholderIcon from "../../assets/icons/logos/logo.svg"
     import DefaultButton from "../Buttons/DefaultButton.svelte";
     import ArrowButton from "../Buttons/ArrowButton.svelte";
 
 
-export let icon = "";
-export let iconAltText = "logo"
-export let labelText = ""
-export let titleText = ""
-export let titleTag = "h3"
-export let subtitleText = ""
-export let paragraphText = ""
-export let buttonText = ""
-export let linkText=""
-export let linkHref=""
 
-export let backgroundColor="transparent"
-export let float = "center"
+
+
+
+
+
+
+
+
 let justify=float;
 let horizontalFloatMargin = "mx-auto"
 

--- a/src/lib/components/FullWidth/ContentBox.svelte
+++ b/src/lib/components/FullWidth/ContentBox.svelte
@@ -1,7 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang='ts'>
-      let { icon = "", iconAltText = "logo", labelText = "", titleText = "", titleTag = "h3", subtitleText = "", paragraphText = "", buttonText = "", linkText = "", linkHref = "", backgroundColor = "transparent", float = "center" }: { icon?: unknown; iconAltText?: unknown; labelText?: unknown; titleText?: unknown; titleTag?: unknown; subtitleText?: unknown; paragraphText?: unknown; buttonText?: unknown; linkText?: unknown; linkHref?: unknown; backgroundColor?: unknown; float?: unknown } = $props();
+      let { icon = "", iconAltText = "logo", labelText = "", titleText = "", titleTag = "h3", subtitleText = "", paragraphText = "", buttonText = "", linkText = "", linkHref = "", backgroundColor = "transparent", float = "center", class: className = "" }: { icon?: unknown; iconAltText?: unknown; labelText?: unknown; titleText?: unknown; titleTag?: unknown; subtitleText?: unknown; paragraphText?: unknown; buttonText?: unknown; linkText?: unknown; linkHref?: unknown; backgroundColor?: unknown; float?: unknown; class?: string } = $props();
 import placeholderIcon from "../../assets/icons/logos/logo.svg"
     import DefaultButton from "../Buttons/DefaultButton.svelte";
     import ArrowButton from "../Buttons/ArrowButton.svelte";
@@ -39,7 +37,7 @@ if(icon==="placeholder"){
 
 </script>
 
-<div class="w-full flex flex-col  p-2 sm:p-8 justify-{justify} text-{float} {$$props.class || ''}"
+<div class="w-full flex flex-col  p-2 sm:p-8 justify-{justify} text-{float} {className || ''}"
      style="background-color: {backgroundColor}"
 >
     {#if icon}

--- a/src/lib/components/FullWidth/FourByThreeImage.svelte
+++ b/src/lib/components/FullWidth/FourByThreeImage.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-    import placeholder from "$lib/assets/images/image_placeholder.svg";
+      let { src = placeholder, alt = "", label = "", loading = "lazy", fetchpriority = "auto" }: { src?: unknown; alt?: unknown; label?: unknown; loading?: "eager" | "lazy"; fetchpriority?: "high" | "low" | "auto" } = $props();
+import placeholder from "$lib/assets/images/image_placeholder.svg";
     import Img from "@zerodevx/svelte-img"
-    
-    export let src = placeholder;
-    export let alt = "";
-    export let label = "";
-    export let loading: "eager" | "lazy" = "lazy";
-    export let fetchpriority: "high" | "low" | "auto" = "auto";
+
+
+
+
+
     let rotationAngle = "36.8";
     let crossLength = "125%";
     

--- a/src/lib/components/FullWidth/FourByThreeImage.svelte
+++ b/src/lib/components/FullWidth/FourByThreeImage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-      let { src = placeholder, alt = "", label = "", loading = "lazy", fetchpriority = "auto" }: { src?: unknown; alt?: unknown; label?: unknown; loading?: "eager" | "lazy"; fetchpriority?: "high" | "low" | "auto" } = $props();
+      let { src = placeholder, alt = "", label = "", loading = "lazy", fetchpriority = "auto", class: className = "" }: { src?: unknown; alt?: unknown; label?: unknown; loading?: "eager" | "lazy"; fetchpriority?: "high" | "low" | "auto"; class?: string } = $props();
 import placeholder from "$lib/assets/images/image_placeholder.svg";
     import Img from "@zerodevx/svelte-img"
 
@@ -12,7 +12,7 @@ import placeholder from "$lib/assets/images/image_placeholder.svg";
     
     </script>
     
-    <div class="w-full relative {$$props.class || ''}">
+    <div class="w-full relative {className || ''}">
       <div class="w-full aspect-[4/3] {src===placeholder ? "border-light border-2 bg-light bg-opacity-25":""} rounded-sm flex items-center justify-center relative">
         {#if typeof src === "object"}
           <Img

--- a/src/lib/components/FullWidth/SquareImage.svelte
+++ b/src/lib/components/FullWidth/SquareImage.svelte
@@ -1,10 +1,8 @@
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang="ts">
-    import placeholder from "$lib/assets/images/image_placeholder.svg"
-
-    export let src = placeholder;
-    export let alt = ""
+      let { src = placeholder, alt = "" }: { src?: unknown; alt?: unknown } = $props();
+import placeholder from "$lib/assets/images/image_placeholder.svg"
 
 
     const rotationAngle = "45";

--- a/src/lib/components/FullWidth/SquareImage.svelte
+++ b/src/lib/components/FullWidth/SquareImage.svelte
@@ -1,7 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang="ts">
-      let { src = placeholder, alt = "" }: { src?: unknown; alt?: unknown } = $props();
+      let { src = placeholder, alt = "", class: className = "" }: { src?: unknown; alt?: unknown; class?: string } = $props();
 import placeholder from "$lib/assets/images/image_placeholder.svg"
 
 
@@ -9,7 +7,7 @@ import placeholder from "$lib/assets/images/image_placeholder.svg"
     let crossLength = "141%";
 </script>
 
-<div class="w-full my-8 {$$props.class || ''}">
+<div class="w-full my-8 {className || ''}">
     <div class="w-full aspect-square {src===placeholder ? "border-light border-2 bg-light bg-opacity-25":""}  rounded-sm  flex items-center justify-center relative">
         <img {src} alt={src===placeholder ? "" : alt} loading="lazy" decoding="async" class="z-10 {src==placeholder ? "w-16 bg-[#F2F5F7]" : "w-full"}"/>
         <div class="absolute bg-light h-[2px] {src===placeholder ? "":"hidden"}" style="transform: rotate({rotationAngle}deg); width:{crossLength}"></div>

--- a/src/lib/components/FullWidth/StyledSingleSelect.svelte
+++ b/src/lib/components/FullWidth/StyledSingleSelect.svelte
@@ -1,7 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang="ts">
-      let { items, value = "", placeholder = "" }: { items: string[]|{label:string,value:string}[]; value?: unknown; placeholder?: unknown } = $props();
+      let { items, value = "", placeholder = "", class: className = "" }: { items: string[]|{label:string,value:string}[]; value?: unknown; placeholder?: unknown; class?: string } = $props();
 import Select from 'svelte-select'
     import dropdownArrow from "$lib/assets/icons/dropdown-arrow-light.svg"
 
@@ -10,7 +8,7 @@ import Select from 'svelte-select'
     let selectHover=false;
 </script>
 
-<div class="max-w-[720px] w-full mx-auto cursor-pointer relative {$$props.class || ''}" role="separator" onmouseover={()=> selectHover=true} onfocus={()=> selectHover=true} onmouseout={()=> selectHover=false} onblur={()=> selectHover=false} >
+<div class="max-w-[720px] w-full mx-auto cursor-pointer relative {className || ''}" role="separator" onmouseover={()=> selectHover=true} onfocus={()=> selectHover=true} onmouseout={()=> selectHover=false} onblur={()=> selectHover=false} >
     <Select {items} bind:value={value} {placeholder} searchable={false} class="svelte-select" />
     <div class="absolute h-full aspect-square right-0 top-0 flex items-center justify-center pointer-events-none">
         <img src={dropdownArrow} alt="" aria-hidden="true" class:opacity-55={selectHover}  class=" transition-all pointer-events-none"/>

--- a/src/lib/components/FullWidth/StyledSingleSelect.svelte
+++ b/src/lib/components/FullWidth/StyledSingleSelect.svelte
@@ -1,19 +1,16 @@
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang="ts">
-    import Select from 'svelte-select'
+      let { items, value = "", placeholder = "" }: { items: string[]|{label:string,value:string}[]; value?: unknown; placeholder?: unknown } = $props();
+import Select from 'svelte-select'
     import dropdownArrow from "$lib/assets/icons/dropdown-arrow-light.svg"
-
-    export let items:string[]|{label:string,value:string}[];
-    export let value="";
-    export let placeholder="";
 
 
 
     let selectHover=false;
 </script>
 
-<div class="max-w-[720px] w-full mx-auto cursor-pointer relative {$$props.class || ''}" role="separator" on:mouseover={()=> selectHover=true} on:focus={()=> selectHover=true} on:mouseout={()=> selectHover=false} on:blur={()=> selectHover=false} >
+<div class="max-w-[720px] w-full mx-auto cursor-pointer relative {$$props.class || ''}" role="separator" onmouseover={()=> selectHover=true} onfocus={()=> selectHover=true} onmouseout={()=> selectHover=false} onblur={()=> selectHover=false} >
     <Select {items} bind:value={value} {placeholder} searchable={false} class="svelte-select" />
     <div class="absolute h-full aspect-square right-0 top-0 flex items-center justify-center pointer-events-none">
         <img src={dropdownArrow} alt="" aria-hidden="true" class:opacity-55={selectHover}  class=" transition-all pointer-events-none"/>

--- a/src/lib/components/FullWidth/TestimonialBox.svelte
+++ b/src/lib/components/FullWidth/TestimonialBox.svelte
@@ -1,13 +1,13 @@
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang="ts">
-export let icon="";
-export let iconAltText="company logo"
-export let testimonialText ="";
-export let attribution = "";
-export let attributionLabel = "";
-export let backgroundColor="transparent"
-export let float = "center"
+
+
+
+
+
+
+  let { icon = "", iconAltText = "company logo", testimonialText = "", attribution = "", attributionLabel = "", backgroundColor = "transparent", float = "center" }: { icon?: unknown; iconAltText?: unknown; testimonialText?: unknown; attribution?: unknown; attributionLabel?: unknown; backgroundColor?: unknown; float?: unknown } = $props();
 let justify=float;
 let horizontalFloatMargin = "mx-auto"
 

--- a/src/lib/components/FullWidth/TestimonialBox.svelte
+++ b/src/lib/components/FullWidth/TestimonialBox.svelte
@@ -1,5 +1,3 @@
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang="ts">
 
 
@@ -7,7 +5,7 @@
 
 
 
-  let { icon = "", iconAltText = "company logo", testimonialText = "", attribution = "", attributionLabel = "", backgroundColor = "transparent", float = "center" }: { icon?: unknown; iconAltText?: unknown; testimonialText?: unknown; attribution?: unknown; attributionLabel?: unknown; backgroundColor?: unknown; float?: unknown } = $props();
+  let { icon = "", iconAltText = "company logo", testimonialText = "", attribution = "", attributionLabel = "", backgroundColor = "transparent", float = "center", class: className = "" }: { icon?: unknown; iconAltText?: unknown; testimonialText?: unknown; attribution?: unknown; attributionLabel?: unknown; backgroundColor?: unknown; float?: unknown; class?: string } = $props();
 let justify=float;
 let horizontalFloatMargin = "mx-auto"
 
@@ -27,7 +25,7 @@ if(float==="right")
 
 </script>
 
-<div class="{$$props.class || ''} w-full flex flex-col  p-2 sm:p-8 justify-{justify} text-{float}"
+<div class="{className || ''} w-full flex flex-col  p-2 sm:p-8 justify-{justify} text-{float}"
      style="background-color: {backgroundColor}"
 >
     {#if icon}

--- a/src/lib/components/FullWidth/TitleBox.svelte
+++ b/src/lib/components/FullWidth/TitleBox.svelte
@@ -1,7 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang='ts'>
-      let { icon = placeholderIcon, iconAltText = "logo", labelText = "", titleText = "", subtitleText = "", paragraphText = "", buttonText = "", linkText = "", linkHref = "", backgroundColor = "transparent", float = "center" }: { icon?: unknown; iconAltText?: unknown; labelText?: unknown; titleText?: unknown; subtitleText?: unknown; paragraphText?: unknown; buttonText?: unknown; linkText?: unknown; linkHref?: unknown; backgroundColor?: unknown; float?: unknown } = $props();
+      let { icon = placeholderIcon, iconAltText = "logo", labelText = "", titleText = "", subtitleText = "", paragraphText = "", buttonText = "", linkText = "", linkHref = "", backgroundColor = "transparent", float = "center", class: className = "" }: { icon?: unknown; iconAltText?: unknown; labelText?: unknown; titleText?: unknown; subtitleText?: unknown; paragraphText?: unknown; buttonText?: unknown; linkText?: unknown; linkHref?: unknown; backgroundColor?: unknown; float?: unknown; class?: string } = $props();
 import placeholderIcon from "../../assets/icons/logos/logo.svg"
     import DefaultButton from "../Buttons/DefaultButton.svelte";
     import ArrowButton from "../Buttons/ArrowButton.svelte";
@@ -31,7 +29,7 @@ if(float==="right")
 let isLinkArrowActive=false;
 </script>
 
-<div class="w-full flex flex-col p-2 md:p-8 justify-{justify} text-{float} {$$props.class || ''}"
+<div class="w-full flex flex-col p-2 md:p-8 justify-{justify} text-{float} {className || ''}"
      style="background-color: {backgroundColor}"
 >
     {#if icon}

--- a/src/lib/components/FullWidth/TitleBox.svelte
+++ b/src/lib/components/FullWidth/TitleBox.svelte
@@ -1,22 +1,20 @@
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang='ts'>
-    import placeholderIcon from "../../assets/icons/logos/logo.svg"
+      let { icon = placeholderIcon, iconAltText = "logo", labelText = "", titleText = "", subtitleText = "", paragraphText = "", buttonText = "", linkText = "", linkHref = "", backgroundColor = "transparent", float = "center" }: { icon?: unknown; iconAltText?: unknown; labelText?: unknown; titleText?: unknown; subtitleText?: unknown; paragraphText?: unknown; buttonText?: unknown; linkText?: unknown; linkHref?: unknown; backgroundColor?: unknown; float?: unknown } = $props();
+import placeholderIcon from "../../assets/icons/logos/logo.svg"
     import DefaultButton from "../Buttons/DefaultButton.svelte";
     import ArrowButton from "../Buttons/ArrowButton.svelte";
 
 
-export let icon = placeholderIcon;
-export let iconAltText = "logo"
-export let labelText = ""
-export let titleText = ""
-export let subtitleText = ""
-export let paragraphText = ""
-export let buttonText = ""
-export let linkText=""
-export let linkHref=""
-export let backgroundColor="transparent"
-export let float = "center"
+
+
+
+
+
+
+
+
 
 let justify=float;
 if(float==="left")

--- a/src/lib/components/HalfWidth/HalfWidthImage.svelte
+++ b/src/lib/components/HalfWidth/HalfWidthImage.svelte
@@ -1,7 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang="ts">
-      let { image = placeholder, alt = "" }: { image?: unknown; alt?: unknown } = $props();
+      let { image = placeholder, alt = "", class: className = "" }: { image?: unknown; alt?: unknown; class?: string } = $props();
 import placeholder from "$lib/assets/images/image_placeholder.svg"
 
 
@@ -9,7 +7,7 @@ import placeholder from "$lib/assets/images/image_placeholder.svg"
     let crossLength = "125%";
 </script>
 
-<div class="w-full lg:w-1/2 my-8 {$$props.class || ''}">
+<div class="w-full lg:w-1/2 my-8 {className || ''}">
     <div class="w-full aspect-[4/3] {image===placeholder ? "border-light border-2 bg-light bg-opacity-25":""}  rounded-sm  flex items-center justify-center relative">
         <img src={image} alt={image===placeholder ? "" : alt} loading="lazy" decoding="async" class="z-10 {image==placeholder ? "w-16 bg-[#F2F5F7]" : "w-full"}"/>
         <div class="absolute bg-light h-[2px] {image===placeholder ? "":"hidden"}" style="transform: rotate({rotationAngle}deg); width:{crossLength}"></div>

--- a/src/lib/components/HalfWidth/HalfWidthImage.svelte
+++ b/src/lib/components/HalfWidth/HalfWidthImage.svelte
@@ -1,9 +1,8 @@
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang="ts">
-    import placeholder from "$lib/assets/images/image_placeholder.svg"
-    export let image = placeholder;
-    export let alt = "";
+      let { image = placeholder, alt = "" }: { image?: unknown; alt?: unknown } = $props();
+import placeholder from "$lib/assets/images/image_placeholder.svg"
 
 
     let rotationAngle = "36.8";

--- a/src/lib/components/ScreenWidth/ScreenWidthGallerySliderLarge.svelte
+++ b/src/lib/components/ScreenWidth/ScreenWidthGallerySliderLarge.svelte
@@ -1,7 +1,8 @@
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang='ts'>
-    import { onMount } from "svelte";
+      let { itemArray = [ }: { itemArray?: GalleryItem[] } = $props();
+import { onMount } from "svelte";
     import { swipe } from "svelte-gestures";
     import placeholder from "../../assets/images/image_placeholder.svg";
     import ContentWidth from "../ContentWidth/ContentWidth.svelte";
@@ -14,8 +15,7 @@
   featuredImage?: string;
   filters?: string[];
 };
-      
-      export let itemArray:GalleryItem[] = [
+
         {
             name: "Item 1",
             featuredText:"Dev + UX",
@@ -128,7 +128,7 @@
   <svelte:window bind:innerWidth />
       
   <section class="pb-32 {$$props.class || ''}">
-      <div use:swipe on:swipe={handleSwipe} class="h-py-2 relative" style="height:{imageWidth*0.95}px;">
+      <div use:swipe onswipe={handleSwipe} class="h-py-2 relative" style="height:{imageWidth*0.95}px;">
       <div  class="h-full flex flex-row flex-nowrap {isSlideAnimated ? 'transition-transform duration-[2000ms]': ''}"
       style= "width:{(imageWidth-8)*tripledItems.length}px; margin-left:calc(50vw - {(imageWidth-8)/2}px); transform:translateX({-(sliderIndex+itemArray.length)*(imageWidth-8)}px); ">   
           {#each tripledItems as item }
@@ -154,7 +154,7 @@
                 {#each  itemArray as item, i}
                     <button class="h-[10px] w-[10px] border-2  rounded-full transition-colors duration-1000 cursor-pointer active:-translate-y-[0.5px] hover:opacity-60 mx-2 translate-x-2
                                     {(sliderIndex%itemArray.length>=0&&sliderIndex%itemArray.length===i)|| (sliderIndex%itemArray.length<=0&&itemArray.length+sliderIndex%itemArray.length===i) ? "bg-dark border-dark" : "border-light"}"
-                        on:click={()=>setSliderIndex(i)}
+                        onclick={()=>setSliderIndex(i)}
                         aria-label="image {i} of {itemArray.length}"
                         aria-hidden
                     ></button>

--- a/src/lib/components/ScreenWidth/ScreenWidthGallerySliderLarge.svelte
+++ b/src/lib/components/ScreenWidth/ScreenWidthGallerySliderLarge.svelte
@@ -1,7 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang='ts'>
-      let { itemArray = [ }: { itemArray?: GalleryItem[] } = $props();
+      let { itemArray = [, class: className = "" }: { itemArray?: GalleryItem[]; class?: string } = $props();
 import { onMount } from "svelte";
     import { swipe } from "svelte-gestures";
     import placeholder from "../../assets/images/image_placeholder.svg";
@@ -127,7 +125,7 @@ import { onMount } from "svelte";
   <svelte:head><title>Portfolios | Reddoor Wireframer</title></svelte:head>
   <svelte:window bind:innerWidth />
       
-  <section class="pb-32 {$$props.class || ''}">
+  <section class="pb-32 {className || ''}">
       <div use:swipe onswipe={handleSwipe} class="h-py-2 relative" style="height:{imageWidth*0.95}px;">
       <div  class="h-full flex flex-row flex-nowrap {isSlideAnimated ? 'transition-transform duration-[2000ms]': ''}"
       style= "width:{(imageWidth-8)*tripledItems.length}px; margin-left:calc(50vw - {(imageWidth-8)/2}px); transform:translateX({-(sliderIndex+itemArray.length)*(imageWidth-8)}px); ">   

--- a/src/lib/components/ScreenWidth/ScreenWidthGallerySliderSmall.svelte
+++ b/src/lib/components/ScreenWidth/ScreenWidthGallerySliderSmall.svelte
@@ -1,7 +1,8 @@
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang='ts'>
-    import { onMount } from "svelte";
+      let { imageArray = [placeholder, placeholder, placeholder, placeholder], altText = "background image" }: { imageArray?: unknown; altText?: unknown } = $props();
+import { onMount } from "svelte";
     import { swipe } from "svelte-gestures";
     import placeholder from "../../assets/images/background_placeholder.svg";
     import ContentWidth from "../ContentWidth/ContentWidth.svelte";
@@ -9,12 +10,7 @@
     import chevronLeft from "$lib/assets/icons/chevron-left.svg"
     import chevronRight from "$lib/assets/icons/chevron-right.svg"
 
-      
-      export let imageArray = [placeholder, placeholder, placeholder, placeholder];
-      export let altText = "background image"
 
-      
-  
       const SLIDER_TRANSITION_FUNCTION="cubic-bezier(.5,0,0,1)";
       const SLIDER_TRANSITION_LENGTH_IN_MS=2000;
       const SLIDER_INTERVAL_IN_MS = 5000;
@@ -95,7 +91,7 @@
   </script>
       
   <section class="pb-32 {$$props.class || ''}">
-      <div use:swipe on:swipe={handleSwipe} class="h-[320px] py-2 relative" >
+      <div use:swipe onswipe={handleSwipe} class="h-[320px] py-2 relative" >
       <div  class="h-full flex flex-row flex-nowrap {isSlideAnimated ? 'transition-transform duration-[2000ms]': ''}"
       style= "width:{352*tripledImages.length}px; margin-left:calc(50vw - 176px); transform:translateX({-(sliderIndex+imageArray.length)*352}px); ">
           
@@ -116,10 +112,10 @@
             <div class="h-full rounded-full absolute top-0 right-0 bg-dark {isSlideAnimated ? 'transition-transform duration-[2000ms]': ''}" style="width:{1/imageArray.length*100}%; transform:translateX({-progressWrapBackwardPosition}%);"></div>
           </div>
 
-          <button on:click={slideLeft} aria-label="Previous image" class="absolute -left-2 h-6 w-6 rounded-full border-[#C2D1D9] border-2 p-1 flex align-middle justify-center cursor-pointer transition-all duration-500 hover:bg-[#424B5A] hover:border-[#424B5A] active:bg-black bump">
+          <button onclick={slideLeft} aria-label="Previous image" class="absolute -left-2 h-6 w-6 rounded-full border-[#C2D1D9] border-2 p-1 flex align-middle justify-center cursor-pointer transition-all duration-500 hover:bg-[#424B5A] hover:border-[#424B5A] active:bg-black bump">
             <img alt='' aria-hidden="true" src={chevronLeft} class='-translate-x-[1px]' />
           </button>
-          <button on:click={slideRight} aria-label="Next image" class="absolute -right-2  -translate-y-[0.7px] h-6 w-6 rounded-full border-[#C2D1D9] border-2 p-1 flex align-middle cursor-pointer transition-all duration-500 justify-center hover:bg-[#424B5A] hover:border-[#424B5A] active:bg-black bump">
+          <button onclick={slideRight} aria-label="Next image" class="absolute -right-2  -translate-y-[0.7px] h-6 w-6 rounded-full border-[#C2D1D9] border-2 p-1 flex align-middle cursor-pointer transition-all duration-500 justify-center hover:bg-[#424B5A] hover:border-[#424B5A] active:bg-black bump">
             <img alt='' aria-hidden="true" src={chevronRight} class='translate-x-[1px] ' />
           </button>
         </ContentWidth>

--- a/src/lib/components/ScreenWidth/ScreenWidthGallerySliderSmall.svelte
+++ b/src/lib/components/ScreenWidth/ScreenWidthGallerySliderSmall.svelte
@@ -1,7 +1,5 @@
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
-<!-- @migration-task Error while migrating Svelte code: $$props is used together with named props in a way that cannot be automatically migrated. -->
 <script lang='ts'>
-      let { imageArray = [placeholder, placeholder, placeholder, placeholder], altText = "background image" }: { imageArray?: unknown; altText?: unknown } = $props();
+      let { imageArray = [placeholder, placeholder, placeholder, placeholder], altText = "background image", class: className = "" }: { imageArray?: unknown; altText?: unknown; class?: string } = $props();
 import { onMount } from "svelte";
     import { swipe } from "svelte-gestures";
     import placeholder from "../../assets/images/background_placeholder.svg";
@@ -90,7 +88,7 @@ import { onMount } from "svelte";
       const tripledImages = imageArray.concat(imageArray).concat(imageArray)
   </script>
       
-  <section class="pb-32 {$$props.class || ''}">
+  <section class="pb-32 {className || ''}">
       <div use:swipe onswipe={handleSwipe} class="h-[320px] py-2 relative" >
       <div  class="h-full flex flex-row flex-nowrap {isSlideAnimated ? 'transition-transform duration-[2000ms]': ''}"
       style= "width:{352*tripledImages.length}px; margin-left:calc(50vw - 176px); transform:translateX({-(sliderIndex+imageArray.length)*352}px); ">

--- a/src/lib/components/ScreenWidth/ScreenWidthImage.svelte
+++ b/src/lib/components/ScreenWidth/ScreenWidthImage.svelte
@@ -1,19 +1,18 @@
 <script lang="ts">
-	import type { ImageField } from "@prismicio/client";
+	  let { src = placeholder, field, altText = "", placeholderSide = "right", vimeoId = "", darken = false, backdrop = false, shorten = false, priority = false }: { src?: string; field: ImageField | null; altText?: unknown; placeholderSide?: unknown; vimeoId?: unknown; darken?: unknown; backdrop?: unknown; shorten?: unknown; priority?: unknown } = $props();
+import type { ImageField } from "@prismicio/client";
 	import placeholder from "../../assets/images/background_placeholder.svg";
 	import ContentWidth from "../ContentWidth/ContentWidth.svelte";
 	import { PrismicImage } from "@prismicio/svelte";
-  
-	export let src: string = placeholder;
-	export let field: ImageField | null;
-	export let altText = "";
-	export let placeholderSide = "right";
-	export let vimeoId = "";
-	export let darken = false;
-	export let backdrop = false;
-	export let shorten = false;
-	export let priority = false;
-  
+
+
+
+
+
+
+
+
+
 	let viewportHeight: number;
 	let viewportWidth: number;
   </script>

--- a/src/lib/components/ScreenWidth/ScreenWidthImage.svelte
+++ b/src/lib/components/ScreenWidth/ScreenWidthImage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	  let { src = placeholder, field, altText = "", placeholderSide = "right", vimeoId = "", darken = false, backdrop = false, shorten = false, priority = false }: { src?: string; field: ImageField | null; altText?: unknown; placeholderSide?: unknown; vimeoId?: unknown; darken?: unknown; backdrop?: unknown; shorten?: unknown; priority?: unknown } = $props();
+	  let { src = placeholder, field, altText = "", placeholderSide = "right", vimeoId = "", darken = false, backdrop = false, shorten = false, priority = false, class: className = "" }: { src?: string; field: ImageField | null; altText?: unknown; placeholderSide?: unknown; vimeoId?: unknown; darken?: unknown; backdrop?: unknown; shorten?: unknown; priority?: unknown; class?: string } = $props();
 import type { ImageField } from "@prismicio/client";
 	import placeholder from "../../assets/images/background_placeholder.svg";
 	import ContentWidth from "../ContentWidth/ContentWidth.svelte";
@@ -77,7 +77,7 @@ import type { ImageField } from "@prismicio/client";
 	</div>
 	<div class="w-screen h-screen absolute top-0 left-0">
 	  <ContentWidth
-		class="{$$props.class || 'flex items-center justify-center'} h-full"
+		class="{className || 'flex items-center justify-center'} h-full"
 	  >
 		<slot />
 	  </ContentWidth>

--- a/src/lib/slices/ContentWidth/index.svelte
+++ b/src/lib/slices/ContentWidth/index.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** @type {import("@prismicio/client").Content.ContentWidthMediaSlice} */
-  export let slice;
+    let { slice } = $props();
+/** @type {import("@prismicio/client").Content.ContentWidthMediaSlice} */
 </script>
 
 <section

--- a/src/lib/slices/Hero/index.svelte
+++ b/src/lib/slices/Hero/index.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** @type {import("@prismicio/client").Content.HeroSlice} */
-  export let slice;
+    let { slice } = $props();
+/** @type {import("@prismicio/client").Content.HeroSlice} */
 </script>
 
 <section

--- a/src/lib/slices/ThreeStepPlan/index.svelte
+++ b/src/lib/slices/ThreeStepPlan/index.svelte
@@ -1,6 +1,6 @@
 <script>
-  /** @type {import("@prismicio/client").Content.ThreeStepPlanSlice} */
-  export let slice;
+    let { slice } = $props();
+/** @type {import("@prismicio/client").Content.ThreeStepPlanSlice} */
 </script>
 
 <section

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -36,8 +36,7 @@
       }
   });
 
-  let content = $state(data.page.data);
-  $effect(() => { data; content = data.page.data });
+  let content = $derived(data.page.data);
 
 </script>
 

--- a/src/routes/[[preview=preview]]/+page.svelte
+++ b/src/routes/[[preview=preview]]/+page.svelte
@@ -26,8 +26,7 @@
   });
 
     let { data } = $props();
-  let content = $state(data.page.data);
-  $effect(() => { data; content = data.page.data });
+  let content = $derived(data.page.data);
 </script>
 
 <svelte:window bind:innerWidth={viewpoortWidth} />

--- a/src/routes/[[preview=preview]]/community/+page.svelte
+++ b/src/routes/[[preview=preview]]/community/+page.svelte
@@ -3,8 +3,7 @@ import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
   import { PrismicImage, PrismicRichText } from "@prismicio/svelte";
 
     let { data } = $props();
-  let content = $state(data.page.data);
-  $effect(() => { data; content = data.page.data });
+  let content = $derived(data.page.data);
 </script>
 
 <ContentWidth class='gap-20 flex flex-col items-start pt-48'>

--- a/src/routes/[[preview=preview]]/contact/+page.svelte
+++ b/src/routes/[[preview=preview]]/contact/+page.svelte
@@ -2,8 +2,7 @@
 import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
   import { PrismicImage, PrismicRichText } from "@prismicio/svelte";
     let { data } = $props();
-  let content = $state(data.page.data);
-  $effect(() => { data; content = data.page.data });
+  let content = $derived(data.page.data);
 </script>
 
 <ContentWidth class='gap-20 flex flex-col items-start pt-48'>

--- a/src/routes/[[preview=preview]]/leasing/+page.svelte
+++ b/src/routes/[[preview=preview]]/leasing/+page.svelte
@@ -4,8 +4,7 @@ import { PrismicImage } from "@prismicio/svelte";
 import ScreenWidthImage from "$lib/components/ScreenWidth/ScreenWidthImage.svelte";
 
  let { data } = $props();
-  let content = $state(data.page.data);
-  $effect(() => { data; content = data.page.data });
+  let content = $derived(data.page.data);
 </script>
 
 <ContentWidth class='flex flex-col items-start justify-start pt-48 pb-24'>

--- a/src/routes/[[preview=preview]]/purchases/+page.svelte
+++ b/src/routes/[[preview=preview]]/purchases/+page.svelte
@@ -23,8 +23,7 @@ let isRequestModalOpen = $state(false);
 
 
    let { data } = $props();
-  let content = $state(data.page.data);
-  $effect(() => { data; content = data.page.data });
+  let content = $derived(data.page.data);
 </script>
 
 {#if isRequestModalOpen}


### PR DESCRIPTION
## Summary

Follow-on to PR #3 — applies the new [`stateEffectSyncToDerived` codemod](https://www.npmjs.com/package/@reddoorla/maintenance/v/0.6.0) and the existing gotcha codemods that had drifted from full Svelte 5 idiom. Plus one manual fix for the `if (isWhite)` reactivity bug in `DefaultButton` that's too contextual for a safe regex codemod.

## Commits

- **`refactor(svelte5): apply codemods (19 files)`** — full gotcha pipeline:
  - **`stateEffectSyncToDerived`** (new in 0.6.0): collapses the `let X = $state(prop.expr); $effect(() => { prop; X = prop.expr })` manual-sync pattern into `let X = $derived(prop.expr)`. Applied to `+layout.svelte`, the root `+page.svelte`, and `[community|contact|leasing|purchases]/+page.svelte`.
  - **`onEventToHandler`**: rewrites leftover `on:click=`, `on:mouseenter=` etc. to `onclick=`, `onmouseenter=` across many components — looks like the original Svelte 4 → 5 migration left these untouched.
- **`fix(buttons): collapse if-mutated state to $derived in DefaultButton`** — manual: `let baseClasses = $state(...); if (isWhite) baseClasses = "..."` only ran at init. Replaced with `$derived(isWhite ? ... : ...)`.

## Clears

After merge + pnpm install + pnpm dev:
- ✅ `state_referenced_locally` warnings (the 3 the user reported in the dev server output)
- ✅ Any lingering Svelte 4 → 5 event-syntax warnings

## Test plan

- [ ] `pnpm install` — should be a noop (no dep changes in this PR)
- [ ] `pnpm dev` — confirm no `state_referenced_locally` warnings
- [ ] `pnpm build` — confirm production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)