### PR TITLE
chore: caltex polish — maint 0.13, adapter-netlify, viewport typo, RequestInfoModal extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@playwright/test": "^1.60.0",
     "@reddoorla/maintenance": "^0.13.0",
     "@slicemachine/adapter-sveltekit": "^0.3.96",
-    "@sveltejs/adapter-auto": "^7.0.1",
+    "@sveltejs/adapter-netlify": "^6.0.4",
     "@sveltejs/kit": "^2.61.1",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tailwindcss/vite": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@axe-core/playwright": "^4.11.3",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.60.0",
-    "@reddoorla/maintenance": "^0.11.2",
+    "@reddoorla/maintenance": "^0.13.0",
     "@slicemachine/adapter-sveltekit": "^0.3.96",
     "@sveltejs/adapter-auto": "^7.0.1",
     "@sveltejs/kit": "^2.61.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,9 @@ importers:
       "@slicemachine/adapter-sveltekit":
         specifier: ^0.3.96
         version: 0.3.96(@prismicio/types@0.2.9)(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(prettier-plugin-svelte@4.0.1(prettier@3.8.3)(svelte@5.55.10(@typescript-eslint/types@8.60.0)))(prettier@3.8.3)(svelte@5.55.10(@typescript-eslint/types@8.60.0))
-      "@sveltejs/adapter-auto":
-        specifier: ^7.0.1
-        version: 7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))
+      "@sveltejs/adapter-netlify":
+        specifier: ^6.0.4
+        version: 6.0.4(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))
       "@sveltejs/kit":
         specifier: ^2.61.1
         version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
@@ -181,6 +181,240 @@ packages:
       {
         integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
       }
+
+  "@esbuild/aix-ppc64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [aix]
+
+  "@esbuild/android-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [android]
+
+  "@esbuild/android-arm@0.25.12":
+    resolution:
+      {
+        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [android]
+
+  "@esbuild/android-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [android]
+
+  "@esbuild/darwin-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@esbuild/darwin-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@esbuild/freebsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@esbuild/linux-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [linux]
+
+  "@esbuild/linux-arm@0.25.12":
+    resolution:
+      {
+        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [linux]
+
+  "@esbuild/linux-ia32@0.25.12":
+    resolution:
+      {
+        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [linux]
+
+  "@esbuild/linux-loong64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
+      }
+    engines: { node: ">=18" }
+    cpu: [loong64]
+    os: [linux]
+
+  "@esbuild/linux-mips64el@0.25.12":
+    resolution:
+      {
+        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [mips64el]
+    os: [linux]
+
+  "@esbuild/linux-ppc64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@esbuild/linux-riscv64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [riscv64]
+    os: [linux]
+
+  "@esbuild/linux-s390x@0.25.12":
+    resolution:
+      {
+        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@esbuild/linux-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [linux]
+
+  "@esbuild/netbsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [netbsd]
+
+  "@esbuild/netbsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [netbsd]
+
+  "@esbuild/openbsd-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [openbsd]
+
+  "@esbuild/openharmony-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@esbuild/sunos-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [sunos]
+
+  "@esbuild/win32-arm64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@esbuild/win32-ia32@0.25.12":
+    resolution:
+      {
+        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.25.12":
+    resolution:
+      {
+        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [win32]
 
   "@eslint-community/eslint-utils@4.9.1":
     resolution:
@@ -339,6 +573,12 @@ packages:
         integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==,
       }
     engines: { node: ">=18.18" }
+
+  "@iarna/toml@2.2.5":
+    resolution:
+      {
+        integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==,
+      }
 
   "@img/sharp-darwin-arm64@0.33.5":
     resolution:
@@ -1306,13 +1546,13 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  "@sveltejs/adapter-auto@7.0.1":
+  "@sveltejs/adapter-netlify@6.0.4":
     resolution:
       {
-        integrity: sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==,
+        integrity: sha512-Ln/vgZc1v/2JFXhl5QiVKJ61a75jKe2rdxMnDO8PPDpQN8Tq/0w4JnBGAMBqENtD+kDACyY00ZTyzP9uTP77wg==,
       }
     peerDependencies:
-      "@sveltejs/kit": ^2.0.0
+      "@sveltejs/kit": ^2.31.0
 
   "@sveltejs/kit@2.61.1":
     resolution:
@@ -2718,6 +2958,14 @@ packages:
         integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==,
       }
     engines: { node: ">= 0.4" }
+
+  esbuild@0.25.12:
+    resolution:
+      {
+        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
 
   escalade@3.2.0:
     resolution:
@@ -6503,6 +6751,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  "@esbuild/aix-ppc64@0.25.12":
+    optional: true
+
+  "@esbuild/android-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/android-arm@0.25.12":
+    optional: true
+
+  "@esbuild/android-x64@0.25.12":
+    optional: true
+
+  "@esbuild/darwin-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/darwin-x64@0.25.12":
+    optional: true
+
+  "@esbuild/freebsd-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/freebsd-x64@0.25.12":
+    optional: true
+
+  "@esbuild/linux-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/linux-arm@0.25.12":
+    optional: true
+
+  "@esbuild/linux-ia32@0.25.12":
+    optional: true
+
+  "@esbuild/linux-loong64@0.25.12":
+    optional: true
+
+  "@esbuild/linux-mips64el@0.25.12":
+    optional: true
+
+  "@esbuild/linux-ppc64@0.25.12":
+    optional: true
+
+  "@esbuild/linux-riscv64@0.25.12":
+    optional: true
+
+  "@esbuild/linux-s390x@0.25.12":
+    optional: true
+
+  "@esbuild/linux-x64@0.25.12":
+    optional: true
+
+  "@esbuild/netbsd-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/netbsd-x64@0.25.12":
+    optional: true
+
+  "@esbuild/openbsd-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/openbsd-x64@0.25.12":
+    optional: true
+
+  "@esbuild/openharmony-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/sunos-x64@0.25.12":
+    optional: true
+
+  "@esbuild/win32-arm64@0.25.12":
+    optional: true
+
+  "@esbuild/win32-ia32@0.25.12":
+    optional: true
+
+  "@esbuild/win32-x64@0.25.12":
+    optional: true
+
   "@eslint-community/eslint-utils@4.9.1(eslint@10.4.0(jiti@2.7.0))":
     dependencies:
       eslint: 10.4.0(jiti@2.7.0)
@@ -6595,6 +6921,8 @@ snapshots:
   "@humanwhocodes/module-importer@1.0.1": {}
 
   "@humanwhocodes/retry@0.4.3": {}
+
+  "@iarna/toml@2.2.5": {}
 
   "@img/sharp-darwin-arm64@0.33.5":
     optionalDependencies:
@@ -7201,9 +7529,11 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  "@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))":
+  "@sveltejs/adapter-netlify@6.0.4(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))":
     dependencies:
+      "@iarna/toml": 2.2.5
       "@sveltejs/kit": 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))
+      esbuild: 0.25.12
 
   "@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0))":
     dependencies:
@@ -8016,6 +8346,35 @@ snapshots:
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      "@esbuild/aix-ppc64": 0.25.12
+      "@esbuild/android-arm": 0.25.12
+      "@esbuild/android-arm64": 0.25.12
+      "@esbuild/android-x64": 0.25.12
+      "@esbuild/darwin-arm64": 0.25.12
+      "@esbuild/darwin-x64": 0.25.12
+      "@esbuild/freebsd-arm64": 0.25.12
+      "@esbuild/freebsd-x64": 0.25.12
+      "@esbuild/linux-arm": 0.25.12
+      "@esbuild/linux-arm64": 0.25.12
+      "@esbuild/linux-ia32": 0.25.12
+      "@esbuild/linux-loong64": 0.25.12
+      "@esbuild/linux-mips64el": 0.25.12
+      "@esbuild/linux-ppc64": 0.25.12
+      "@esbuild/linux-riscv64": 0.25.12
+      "@esbuild/linux-s390x": 0.25.12
+      "@esbuild/linux-x64": 0.25.12
+      "@esbuild/netbsd-arm64": 0.25.12
+      "@esbuild/netbsd-x64": 0.25.12
+      "@esbuild/openbsd-arm64": 0.25.12
+      "@esbuild/openbsd-x64": 0.25.12
+      "@esbuild/openharmony-arm64": 0.25.12
+      "@esbuild/sunos-x64": 0.25.12
+      "@esbuild/win32-arm64": 0.25.12
+      "@esbuild/win32-ia32": 0.25.12
+      "@esbuild/win32-x64": 0.25.12
 
   escalade@3.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
       "@reddoorla/maintenance":
-        specifier: ^0.11.2
-        version: 0.11.2(jiti@2.7.0)(playwright-core@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
+        specifier: ^0.13.0
+        version: 0.13.0(jiti@2.7.0)(playwright-core@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
       "@slicemachine/adapter-sveltekit":
         specifier: ^0.3.96
         version: 0.3.96(@prismicio/types@0.2.9)(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(prettier-plugin-svelte@4.0.1(prettier@3.8.3)(svelte@5.55.10(@typescript-eslint/types@8.60.0)))(prettier@3.8.3)(svelte@5.55.10(@typescript-eslint/types@8.60.0))
@@ -780,10 +780,10 @@ packages:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
-  "@reddoorla/maintenance@0.11.2":
+  "@reddoorla/maintenance@0.13.0":
     resolution:
       {
-        integrity: sha512-UyFNUa260ZOJzVZgrt9i8JqDBwMQFD0Dm5T725OwZWogiIqyidxePa26o9gpZJn4mVVkfXpiKxVVDmgKCjyk8A==,
+        integrity: sha512-+Sk2HLuOqL4x7bkngxDFYFp6v5O+rvvYr5nB+d/az3RODjzGq+NuG3IlI4fRCQZD1nw8D8JjomOyj4cx1SJQnQ==,
       }
     engines: { node: ">=20" }
     hasBin: true
@@ -6883,7 +6883,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       react-promise-suspense: 0.3.4
 
-  "@reddoorla/maintenance@0.11.2(jiti@2.7.0)(playwright-core@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)":
+  "@reddoorla/maintenance@0.13.0(jiti@2.7.0)(playwright-core@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)":
     dependencies:
       "@axe-core/playwright": 4.11.3(playwright-core@1.60.0)
       "@eslint/js": 10.0.1(eslint@10.4.0(jiti@2.7.0))

--- a/src/lib/components/RequestInfoModal.svelte
+++ b/src/lib/components/RequestInfoModal.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { fade } from "svelte/transition";
+  import { X } from "@lucide/svelte";
+  import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
+  import { requestModal } from "$lib/stores/requestModal.svelte";
+  import { CONTACT } from "$lib/constants/contact";
+
+  // Lock body scroll while the modal is open.
+  $effect(() => {
+    const body = document.body;
+    if (!body) return;
+    body.style.overflow = requestModal.isOpen ? "hidden" : "auto";
+    return () => {
+      body.style.overflow = "auto";
+    };
+  });
+</script>
+
+{#if requestModal.isOpen}
+  <div
+    class="w-screen h-screen fixed top-0 left-0 bg-black bg-opacity-80 backdrop-blur z-30 flex items-center justify-center"
+    transition:fade
+  >
+    <button
+      onclick={() => requestModal.close()}
+      class="w-screen h-screen absolute top-0 left-0"
+      aria-label="close"
+    >
+    </button>
+
+    <ContentWidth
+      class="blur-none bg-primary h-4/5 md:h-3/5 relative rounded-lg flex flex-col items-center justify-center text-center gap-16 px-3 sm:px-9 md:px-16"
+    >
+      <button
+        class="absolute top-6 right-6 pointer-events-auto"
+        onclick={() => requestModal.close()}
+        aria-label="close"
+      >
+        <X size={24} />
+      </button>
+      <h2 class="text-white">
+        <span>Choosing our&nbsp;</span><span> AED services&nbsp;</span><span>
+          ensures your readiness&nbsp;</span
+        ><span> for emergencies.</span>
+      </h2>
+      <h3 class="text-white">
+        Contact {CONTACT.name} at
+        <a href="mailto:{CONTACT.email}" class="text-black">{CONTACT.email}</a> <br /> or leave a
+        message
+        <a href="tel:{CONTACT.phoneTel}" class="text-black">{CONTACT.phoneDisplay}</a>
+      </h3>
+    </ContentWidth>
+  </div>
+{/if}

--- a/src/lib/constants/contact.ts
+++ b/src/lib/constants/contact.ts
@@ -1,0 +1,14 @@
+/**
+ * Single source of truth for the site's public contact info.
+ *
+ * Until this graduates to a Prismic global doc, edits here ship via a
+ * code release. Keep `email` and `phoneTel` in sync with their display
+ * forms — the prior typo (Ryan Kohen vs Kohnen) only happened because
+ * the same name was hand-copied across five files.
+ */
+export const CONTACT = {
+  name: "Ryan Kohnen",
+  email: "ryan@ryankohnen.com",
+  phoneDisplay: "210.273.7767",
+  phoneTel: "210-273-7767",
+} as const;

--- a/src/lib/stores/requestModal.svelte.ts
+++ b/src/lib/stores/requestModal.svelte.ts
@@ -1,0 +1,23 @@
+/**
+ * Global "Request Info" modal visibility. Every page used to declare
+ * its own `let isRequestModalOpen = $state(false)` plus an identical
+ * `$effect` to lock body scroll — this hoists both into one place so
+ * the markup lives once (in <RequestInfoModal>, rendered by the root
+ * layout) and any page's "Request Info" button just calls open().
+ */
+function createRequestModal() {
+  let isOpen = $state(false);
+  return {
+    get isOpen() {
+      return isOpen;
+    },
+    open() {
+      isOpen = true;
+    },
+    close() {
+      isOpen = false;
+    },
+  };
+}
+
+export const requestModal = createRequestModal();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,7 +19,7 @@
   /** @type {Props} */
   let { children, data, ..._rest } = $props();
 
-  let viewpoortWidth = $state(1024);
+  let viewportWidth = $state(1024);
   let isRequestModalOpen = $state(false);
   let showNav = $state(false);
 
@@ -50,13 +50,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no" />
 </svelte:head>
 
-<svelte:window bind:innerWidth={viewpoortWidth} />
+<svelte:window bind:innerWidth={viewportWidth} />
 <main>
   <nav class="w-screen absolute top-0 left-0 z-20">
     <ContentWidth class="flex flex-row justify-between items-center h-36">
       <a href="/" onclick={() => (showNav = false)}>
         <PrismicImage
-          field={viewpoortWidth > 768 ? content.logo : content.logo_mark}
+          field={viewportWidth > 768 ? content.logo : content.logo_mark}
           loading="eager"
           fetchpriority="high"
           class="w-auto h-10"
@@ -148,7 +148,7 @@
       <ContentWidth class="flex flex-col md:flex-row justify-between items-center gap-8">
         <a href="/" onclick={() => (showNav = false)}>
           <PrismicImage
-            field={viewpoortWidth > 768 ? content.logo : content.logo_mark}
+            field={viewportWidth > 768 ? content.logo : content.logo_mark}
             loading="lazy"
             class="w-auto h-10"
           />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,10 +6,13 @@
   import "../fonts.css";
   import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
   import ScreenWidthImage from "$lib/components/ScreenWidth/ScreenWidthImage.svelte";
+  import RequestInfoModal from "$lib/components/RequestInfoModal.svelte";
   import { PrismicImage } from "@prismicio/svelte";
   import DefaultButton from "$lib/components/Buttons/DefaultButton.svelte";
   import { fade } from "svelte/transition";
-  import { Menu, X } from "@lucide/svelte";
+  import { Menu } from "@lucide/svelte";
+  import { requestModal } from "$lib/stores/requestModal.svelte";
+  import { CONTACT } from "$lib/constants/contact";
 
   /**
    * @typedef {Object} Props
@@ -20,17 +23,7 @@
   let { children, data, ..._rest } = $props();
 
   let viewportWidth = $state(1024);
-  let isRequestModalOpen = $state(false);
   let showNav = $state(false);
-
-  $effect(() => {
-    if (document.getElementsByTagName("body"))
-      if (isRequestModalOpen) {
-        (document.getElementsByTagName("body")[0] as HTMLElement).style.overflow = "hidden";
-      } else {
-        (document.getElementsByTagName("body")[0] as HTMLElement).style.overflow = "auto";
-      }
-  });
 
   let content = $derived(data.page.data);
 </script>
@@ -63,7 +56,7 @@
         />
       </a>
       <div class="flex flex-row justify-between gap-6 items-center">
-        <DefaultButton onclick={() => (isRequestModalOpen = true)}>Request Info</DefaultButton>
+        <DefaultButton onclick={() => requestModal.open()}>Request Info</DefaultButton>
         <button onclick={() => (showNav = !showNav)} aria-label="toggle nav"
           ><Menu size={24} /></button
         >
@@ -71,42 +64,7 @@
     </ContentWidth>
   </nav>
 
-  {#if isRequestModalOpen}
-    <div
-      class="w-screen h-screen fixed top-0 left-0 bg-black bg-opacity-80 backdrop-blur z-30 flex items-center justify-center"
-      transition:fade
-    >
-      <button
-        onclick={() => (isRequestModalOpen = false)}
-        class="w-screen h-screen absolute top-0 left-0"
-        aria-label="close"
-      >
-      </button>
-
-      <ContentWidth
-        class="blur-none bg-primary h-4/5 md:h-3/5 relative rounded-lg flex flex-col items-center justify-center text-center gap-16 px-3 sm:px-9 md:px-16"
-      >
-        <button
-          class="absolute top-6 right-6 pointer-events-auto"
-          onclick={() => (isRequestModalOpen = false)}
-          aria-label="close"
-        >
-          <X size={24} />
-        </button>
-        <h2 class="text-white">
-          <span>Choosing our&nbsp;</span><span> AED services&nbsp;</span><span>
-            ensures your readiness&nbsp;</span
-          ><span> for emergencies.</span>
-        </h2>
-        <h3 class="text-white">
-          Contact Ryan Kohnen at <a href="mailto:ryan@ryankohnen.com" class="text-black"
-            >ryan@ryankohnen.com</a
-          > <br /> or leave a message
-          <a href="tel:210.273.7767" class="text-black">210.273.7767</a>
-        </h3>
-      </ContentWidth>
-    </div>
-  {/if}
+  <RequestInfoModal />
 
   <ScreenWidthImage
     field={content.background_image}
@@ -154,8 +112,8 @@
           />
         </a>
         <div class="flex flex-col md:flex-row gap-8">
-          <a href="mailto:ryan@ryankohnen.com">ryan@ryankohnen.com</a>
-          <a href="tel:210.273.7767">210.273.7767</a>
+          <a href="mailto:{CONTACT.email}">{CONTACT.email}</a>
+          <a href="tel:{CONTACT.phoneTel}">{CONTACT.phoneDisplay}</a>
         </div>
         <div class="flex flex-col md:flex-row gap-8">
           {"©" + new Date().getFullYear() + "  |   All right reserved"}

--- a/src/routes/[[preview=preview]]/+page.svelte
+++ b/src/routes/[[preview=preview]]/+page.svelte
@@ -1,60 +1,11 @@
 <script lang="ts">
   import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
   import { PrismicImage } from "@prismicio/svelte";
-  import { fade } from "svelte/transition";
-  import { X } from "@lucide/svelte";
-
-  let isRequestModalOpen = $state(false);
-
-  $effect(() => {
-    if (document.getElementsByTagName("body"))
-      if (isRequestModalOpen) {
-        (document.getElementsByTagName("body")[0] as HTMLElement).style.overflow = "hidden";
-      } else {
-        (document.getElementsByTagName("body")[0] as HTMLElement).style.overflow = "auto";
-      }
-  });
 
   let { data, ..._rest } = $props();
   let content = $derived(data.page.data);
 </script>
 
-{#if isRequestModalOpen}
-  <div
-    class="w-screen h-screen fixed top-0 left-0 bg-black bg-opacity-80 backdrop-blur z-30 flex items-center justify-center"
-    transition:fade
-  >
-    <button
-      onclick={() => (isRequestModalOpen = false)}
-      class="w-screen h-screen absolute top-0 left-0"
-      aria-label="close"
-    >
-    </button>
-
-    <ContentWidth
-      class="blur-none bg-primary h-4/5 md:h-3/5 relative rounded-lg flex flex-col items-center justify-center text-center gap-16 px-3 sm:px-9 md:px-16"
-    >
-      <button
-        class="absolute top-6 right-6 pointer-events-auto"
-        onclick={() => (isRequestModalOpen = false)}
-        aria-label="close"
-      >
-        <X size={24} />
-      </button>
-      <h2 class="text-white">
-        <span>Choosing our&nbsp;</span><span> AED services&nbsp;</span><span>
-          ensures your readiness&nbsp;</span
-        ><span> for emergencies.</span>
-      </h2>
-      <h3 class="text-white">
-        Contact Ryan Kohnen at <a href="mailto:ryan@ryankohnen.com" class="text-black"
-          >ryan@ryankohnen.com</a
-        > <br /> or leave a message
-        <a href="tel:210.273.7767" class="text-black">210.273.7767</a>
-      </h3>
-    </ContentWidth>
-  </div>
-{/if}
 <div class="lg:h-12 xl:h-0"></div>
 <section id="s1" class="h-screen w-screen overflow-hidden">
   <ContentWidth class="flex flex-col h-full items-start justify-end relative">
@@ -84,7 +35,11 @@
   </ContentWidth>
 </section>
 
-<!-- 
+<!--
+Disabled marketing sections — re-enable by replacing the
+`isRequestModalOpen = true` triggers with `requestModal.open()`
+from `$lib/stores/requestModal.svelte`.
+
 <section
   id="s4"
   class="w-screen bg-primary text-white mt-16 py-16 md:mt-24 md:py-24 relative overflow-hidden"

--- a/src/routes/[[preview=preview]]/+page.svelte
+++ b/src/routes/[[preview=preview]]/+page.svelte
@@ -4,8 +4,6 @@
   import { fade } from "svelte/transition";
   import { X } from "@lucide/svelte";
 
-  let viewpoortWidth = $state(1024);
-
   let isRequestModalOpen = $state(false);
 
   $effect(() => {
@@ -20,8 +18,6 @@
   let { data, ..._rest } = $props();
   let content = $derived(data.page.data);
 </script>
-
-<svelte:window bind:innerWidth={viewpoortWidth} />
 
 {#if isRequestModalOpen}
   <div

--- a/src/routes/[[preview=preview]]/contact/+page.svelte
+++ b/src/routes/[[preview=preview]]/contact/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
   import { PrismicImage, PrismicRichText } from "@prismicio/svelte";
+  import { CONTACT } from "$lib/constants/contact";
   let { data, ..._rest } = $props();
   let content = $derived(data.page.data);
 </script>
@@ -39,7 +40,7 @@
               fill="#EA7724"
             />
           </svg>
-          <p class="font-medium translate-y-0.5">ryan@ryankohnen.com</p>
+          <p class="font-medium translate-y-0.5">{CONTACT.email}</p>
         </div>
         <div class="w-full h-12 flex items-center pr-10">
           <svg
@@ -55,7 +56,7 @@
               fill="#EA7724"
             />
           </svg>
-          <p class="font-medium translate-y-0.5">210.273.7767</p>
+          <p class="font-medium translate-y-0.5">{CONTACT.phoneDisplay}</p>
         </div>
       </div>
     </div>

--- a/src/routes/[[preview=preview]]/purchases/+page.svelte
+++ b/src/routes/[[preview=preview]]/purchases/+page.svelte
@@ -1,62 +1,12 @@
 <script lang="ts">
   import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
-
   import { PrismicImage } from "@prismicio/svelte";
   import DefaultButton from "$lib/components/Buttons/DefaultButton.svelte";
-  import { fade } from "svelte/transition";
-  import { X } from "@lucide/svelte";
-
-  let isRequestModalOpen = $state(false);
-
-  $effect(() => {
-    if (document.getElementsByTagName("body"))
-      if (isRequestModalOpen) {
-        (document.getElementsByTagName("body")[0] as HTMLElement).style.overflow = "hidden";
-      } else {
-        (document.getElementsByTagName("body")[0] as HTMLElement).style.overflow = "auto";
-      }
-  });
+  import { requestModal } from "$lib/stores/requestModal.svelte";
 
   let { data, ..._rest } = $props();
   let content = $derived(data.page.data);
 </script>
-
-{#if isRequestModalOpen}
-  <div
-    class="w-screen h-screen fixed top-0 left-0 bg-black bg-opacity-80 backdrop-blur z-30 flex items-center justify-center"
-    transition:fade
-  >
-    <button
-      onclick={() => (isRequestModalOpen = false)}
-      class="w-screen h-screen absolute top-0 left-0"
-      aria-label="close"
-    >
-    </button>
-
-    <ContentWidth
-      class="blur-none bg-primary h-4/5 md:h-3/5 relative rounded-lg flex flex-col items-center justify-center text-center gap-16 px-3 sm:px-9 md:px-16"
-    >
-      <button
-        class="absolute top-6 right-6 pointer-events-auto"
-        onclick={() => (isRequestModalOpen = false)}
-        aria-label="close"
-      >
-        <X size={24} />
-      </button>
-      <h2 class="text-white">
-        <span>Choosing our&nbsp;</span><span> AED services&nbsp;</span><span>
-          ensures your readiness&nbsp;</span
-        ><span> for emergencies.</span>
-      </h2>
-      <h3 class="text-white">
-        Contact Ryan Kohnen at <a href="mailto:ryan@ryankohnen.com" class="text-black"
-          >ryan@ryankohnen.com</a
-        > <br /> or leave a message
-        <a href="tel:210.273.7767" class="text-black">210.273.7767</a>
-      </h3>
-    </ContentWidth>
-  </div>
-{/if}
 
 <ContentWidth class="gap-20 flex flex-col items-start pt-48">
   <h1>AED Purchases</h1>
@@ -93,9 +43,7 @@
         {/each}
       </div>
       <div class="mt-12 lg:mt-0">
-        <DefaultButton class="mt-6" onclick={() => (isRequestModalOpen = true)}
-          >Request Info</DefaultButton
-        >
+        <DefaultButton class="mt-6" onclick={() => requestModal.open()}>Request Info</DefaultButton>
       </div>
     </div>
   </ContentWidth>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,7 +1,7 @@
 import { createSvelteConfig } from "@reddoorla/maintenance/configs/svelte";
-import adapter from "@sveltejs/adapter-auto";
+import adapter from "@sveltejs/adapter-netlify";
 
 /** @type {import('@sveltejs/kit').Config} */
 export default createSvelteConfig({
-  kit: { adapter: adapter() },
+  kit: { adapter: adapter({ edge: false, split: false }) },
 });


### PR DESCRIPTION
Four small, independently-reviewable commits.

## `f23f6c7` chore(deps): bump @reddoorla/maintenance ^0.11.2 → ^0.13.0
Picks up the refreshed baselines from [reddoor-maintenance#74](https://github.com/tucksravin/reddoor-maintenance/pull/74).
**Deps audit: warn → pass** (all 23 tracked deps in line with baseline).

## `a7d8632` chore(adapter): swap @sveltejs/adapter-auto → @sveltejs/adapter-netlify
Per the svelte4-to-5 skill's gotcha list. adapter-auto silently picked Netlify
in CI but emitted *"Could not detect a supported production environment"* on
local builds. Now: `Using @sveltejs/adapter-netlify ✔ done` with no warning.
Configured `edge: false, split: false` to match the rest of the fleet.

## `e7fe797` fix(typo): viewpoortWidth → viewportWidth + drop dead binding
- Rename in `+layout.svelte` (4 refs; the var is actually used on L59/L151 to
  swap logo/logo_mark at the 768px breakpoint).
- In the home `+page.svelte`, delete both the declaration and the
  `<svelte:window bind:innerWidth>` — the home page never read the value,
  just bound it.

## `863e7fa` refactor(modal): extract `<RequestInfoModal>` + centralize contact info

Three pages each declared their own `let isRequestModalOpen = $state(false)`
plus an identical body-scroll-lock `$effect`, and the modal markup —
~35 lines of identical HTML — was copy-pasted three times. The Kohnen typo
in PR #7 only happened because the contact name was hand-copied across
five places.

**New files:**
- `src/lib/constants/contact.ts` — single source of truth for name / email /
  phoneDisplay / phoneTel
- `src/lib/stores/requestModal.svelte.ts` — tiny runed store: `isOpen` getter +
  `open()` / `close()` (replaces 3× local `$state`)
- `src/lib/components/RequestInfoModal.svelte` — owns the markup + scroll-lock
  `$effect`, reads from both above

**Updated callers:**
- `+layout.svelte` — renders `<RequestInfoModal />` once; navbar button →
  `requestModal.open()`; footer email/phone → `CONTACT.*`
- home `+page.svelte` — drop local modal state + `$effect` + 35-line markup;
  commented s4/s6 blocks get a header note pointing future maintainers at
  the store
- `purchases/+page.svelte` — same drop; "Request Info" button → `requestModal.open()`
- `contact/+page.svelte` — displayed email + phone read from `CONTACT`
  (visual unchanged)

**Net: −150 lines** across the routes. The next "Ryan changed his phone number"
edit is one file instead of five.

## Verification

| Gate | Result |
|---|---|
| `pnpm format` | clean |
| `pnpm lint` | pass |
| `pnpm check` | 0 errors / 0 warnings |
| `pnpm build` | pass, `Using @sveltejs/adapter-netlify ✔ done` |
| `pnpm exec reddoor-maint audit --only deps` | **pass** (was warn) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)