### PR TITLE
fix(netlify): NODE_VERSION 22 (preempt eslint 10 engine)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,5 +4,5 @@
     functions = "functions/"
 
 [build.environment]
-    NODE_VERSION = "22.12.0"
+    NODE_VERSION = "22"
     COREPACK_INTEGRITY_KEYS = "0"


### PR DESCRIPTION
caltex's `netlify.toml` pins `NODE_VERSION = "22.12.0"`, which is below `@eslint/js@10`'s `^22.13.0` engine. It builds today only because the lockfile predates `@eslint/js@10.0.1` — the next Renovate bump would break the Netlify install (this is exactly what bit erp). Bare `"22"` resolves to the latest 22.x (≥22.13). Matches erp and the new sync-configs `netlify.toml` template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)