### PR TITLE
chore: netlify post-transfer deploy canary

### DIFF
--- a/static/_transfer-canary.txt
+++ b/static/_transfer-canary.txt
@@ -1,0 +1,1 @@
+reddoorla-transfer-canary-20260605


### PR DESCRIPTION
Temporary marker to confirm Netlify still auto-deploys after the org move to reddoorla. Safe to merge + revert.