### PR TITLE
fix(ci): renovate action pin v40 -> v46.1.14

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: renovatebot/github-action@v40
+      - uses: renovatebot/github-action@v46.1.14
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:


### PR DESCRIPTION
The `@v40` tag no longer resolves (action ships full-version tags, now v46.x), so the weekly renovate workflow failed at action resolution on every fleet repo. Pin to a current version; Renovate self-maintains it after.