### PR TITLE
chore: remove netlify transfer canary marker

### DIFF
--- a/static/_transfer-canary.txt
+++ b/static/_transfer-canary.txt
@@ -1,1 +1,0 @@
-reddoorla-transfer-canary-20260605


### PR DESCRIPTION
Removes the temporary marker added to confirm Netlify auto-deploy survived the org move. Deploy was confirmed; marker no longer needed.