### PR TITLE
chore(M7.1): adopt reusable CI workflow + org Renovate preset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,29 +3,6 @@ on:
   pull_request:
   push:
     branches: [main]
-permissions:
-  contents: read
 jobs:
   ci:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm exec prettier --check .
-      - run: pnpm exec eslint .
-      - run: pnpm exec svelte-kit sync && pnpm exec svelte-check --tsconfig ./tsconfig.json
-      - run: pnpm build
-      - run: pnpm exec playwright install --with-deps chromium
-      - run: pnpm exec reddoor-maint audit --only a11y --fail-on-violations
-      - name: Test (if present)
-        run: |
-          if node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
-            pnpm test
-          else
-            echo "no test script — skipping"
-          fi
+    uses: reddoorla/.github/.github/workflows/ci.yml@78c4da64b675f0f474961f12715f2a4c09d46eb5 # v1.0.0

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@axe-core/playwright": "^4.11.3",
     "@lhci/cli": "^0.15.1",
     "@playwright/test": "^1.60.0",
-    "@reddoorla/maintenance": "^0.23.0",
+    "@reddoorla/maintenance": "^0.28.0",
     "@slicemachine/adapter-sveltekit": "^0.3.96",
     "@sveltejs/adapter-netlify": "^6.0.4",
     "@sveltejs/kit": "^2.61.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
       '@reddoorla/maintenance':
-        specifier: ^0.23.0
-        version: 0.23.0(jiti@2.7.0)(playwright-core@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
+        specifier: ^0.28.0
+        version: 0.28.0(jiti@2.7.0)(playwright-core@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
       '@slicemachine/adapter-sveltekit':
         specifier: ^0.3.96
         version: 0.3.96(@prismicio/types@0.2.9)(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(jiti@2.7.0)))(prettier-plugin-svelte@4.0.1(prettier@3.8.3)(svelte@5.55.10(@typescript-eslint/types@8.60.0)))(prettier@3.8.3)(svelte@5.55.10(@typescript-eslint/types@8.60.0))
@@ -873,8 +873,8 @@ packages:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
-  '@reddoorla/maintenance@0.23.0':
-    resolution: {integrity: sha512-f0+KLCX0i+9nJ1nDAaxuvGRYL7ePHl9oHfmiXvVadkhbRptocPmio9vij8sBDp7v0tVgPC6PSyLmxw/lm0AETQ==}
+  '@reddoorla/maintenance@0.28.0':
+    resolution: {integrity: sha512-Lc4qWBWKG5ZLVWrNGH6oSBIYNtEcPaH54k9kXWa3SkTbMpdcm0JjZnFnw3G3FNA9rgllk2cpNcSHm+SosVAcwA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -5017,7 +5017,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       react-promise-suspense: 0.3.4
 
-  '@reddoorla/maintenance@0.23.0(jiti@2.7.0)(playwright-core@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)':
+  '@reddoorla/maintenance@0.28.0(jiti@2.7.0)(playwright-core@1.60.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)':
     dependencies:
       '@axe-core/playwright': 4.11.3(playwright-core@1.60.0)
       '@eslint/js': 10.0.1(eslint@10.4.0(jiti@2.7.0))

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "schedule": ["before 7am on monday"],
-  "packageRules": [
-    { "matchUpdateTypes": ["patch", "minor"], "automerge": true, "platformAutomerge": true },
-    { "matchUpdateTypes": ["major"], "automerge": false }
-  ]
+  "extends": ["github>reddoorla/.github:renovate-config"]
 }


### PR DESCRIPTION
M7.1 canary migration. Switches CI to the reddoorla/.github reusable workflow (SHA-pinned) and renovate.json to extend the org preset.