### PR TITLE
chore: restore netlify security headers (re-sync canonical netlify.toml)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,26 @@
 [build.environment]
     NODE_VERSION = "22"
     COREPACK_INTEGRITY_KEYS = "0"
+
+# Baseline security headers for all responses. CSP is emitted per-response by
+# SvelteKit (see `kit.csp` in svelte.config.js) so it is intentionally omitted
+# here to avoid conflicting duplicates.
+[[headers]]
+    for = "/*"
+    [headers.values]
+        Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
+        X-Content-Type-Options = "nosniff"
+        X-Frame-Options = "SAMEORIGIN"
+        Referrer-Policy = "strict-origin-when-cross-origin"
+        Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
+        Cross-Origin-Opener-Policy = "same-origin"
+
+[[headers]]
+    for = "/favicon.png"
+    [headers.values]
+        Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+    for = "/_app/immutable/*"
+    [headers.values]
+        Cache-Control = "public, max-age=31536000, immutable"


### PR DESCRIPTION
A prior `sync-configs` run **stripped this site's baseline security headers** (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, Cross-Origin-Opener-Policy, immutable cache-control) — the canonical `@reddoorla/maintenance` netlify template shipped without them.

The template is now fixed ([reddoor-maintenance#138](https://github.com/reddoorla/reddoor-maintenance/pull/138)): it ships the baseline headers and a `[[headers]]`-aware carve-out so this can never happen again. This re-syncs `netlify.toml` to the corrected canonical, **restoring the headers** (and any drift in build settings, e.g. the Node 22 pin). Generated by `reddoor-maint sync-configs --only netlify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
