### PR TITLE
chore(forms): clean up dead form remnants

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,0 @@
-declare namespace svelteHTML {
-  interface HTMLAttributes<T> {
-    netlify?: boolean;
-    "netlify-honeypot"?: string;
-  }
-}


### PR DESCRIPTION
Fleet forms audit follow-up: removes dead Netlify-Forms / old-mechanism remnants now that the site is on the central ingest (or, for env-only changes, documents/placeholders the FORMS_INGEST vars). No runtime/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)