### PR TITLE
perf(best-practices): gate Prismic toolbar + dnt=1 on Vimeo embeds

### DIFF
--- a/src/lib/components/ScreenWidth/ScreenWidthImage.svelte
+++ b/src/lib/components/ScreenWidth/ScreenWidthImage.svelte
@@ -72,7 +72,7 @@
     {#if vimeoId}
       <iframe
         title="background video"
-        src={`https://player.vimeo.com/video/${vimeoId}?background=1&muted=1&loop=1&autoplay=1`}
+        src={`https://player.vimeo.com/video/${vimeoId}?background=1&muted=1&loop=1&autoplay=1&dnt=1`}
         class="aspect-video absolute {viewportHeight * 16 > viewportWidth * 9
           ? 'h-screen min-w-full'
           : 'w-screen min-h-full'} contrast-[1.15] -z-10"

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -3,6 +3,8 @@ export const prerender = "auto";
 import { createClient } from "$lib/prismicio";
 
 export async function load({ fetch, cookies }) {
+  const isPreviewSession = !!cookies.get("io.prismic.preview");
+
   const client = createClient({ fetch, cookies });
 
   const page = await client.getSingle("home");
@@ -13,5 +15,6 @@ export async function load({ fetch, cookies }) {
     meta_description: page.data.meta_description,
     meta_title: page.data.meta_title,
     meta_image: page.data.meta_image.url,
+    isPreviewSession,
   };
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -122,6 +122,6 @@
     </footer>
   {/if}
 </main>
-{#if !$page.url.pathname.startsWith("/dev/")}
+{#if data.isPreviewSession && !$page.url.pathname.startsWith("/dev/")}
   <PrismicPreview {repositoryName} />
 {/if}


### PR DESCRIPTION
## What
Gate the Prismic toolbar behind an active preview session and add `dnt=1` to every Vimeo embed.

## Why
Lighthouse **Best Practices** was ~78. Two third-party-cookie sources caused it:
- `<PrismicPreview>` injects ~21 third-party cookies for *every* visitor. Now gated on the `io.prismic.preview` cookie — editors arriving via a preview link still get the toolbar; normal visitors get zero cookies.
- Vimeo embeds set tracking cookies without `dnt=1`. Added to all embeds.

Mirrors the fix already proven on reddoorla.com (Best Practices 78→100). `svelte-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)