### PR TITLE
fix(build): declare sharp as explicit devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-svelte": "^3.18.0",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^4.0.1",
+    "sharp": "^0.33.5",
     "slice-machine-ui": "^2.21.3",
     "svelte": "^5.55.10",
     "svelte-check": "^4.4.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       prettier-plugin-svelte:
         specifier: ^4.0.1
         version: 4.0.1(prettier@3.8.3)(svelte@5.55.10(@typescript-eslint/types@8.60.0))
+      sharp:
+        specifier: ^0.33.5
+        version: 0.33.5
       slice-machine-ui:
         specifier: ^2.21.3
         version: 2.21.3(@prismicio/types@0.2.9)(zod@3.25.76)
@@ -4776,7 +4779,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':


### PR DESCRIPTION
## Problem
The image pipeline (`@zerodevx/svelte-img` → `vite-imagetools` → `imagetools-core`) imports `sharp` at build time but never declares it as a runtime dependency. `sharp` only resolves by accident — when some other transitive dep hoists it where `vite-imagetools` can reach it. A routine dependency bump (e.g. `@reddoorla/maintenance`) removes that accident and the **Netlify build dies**:

```
ERR_MODULE_NOT_FOUND: Cannot find package 'sharp' imported from .../vite-imagetools/dist/index.js
failed to load config from vite.config.js  →  exit 1
```

This already hit `gallerysonder` in production (PR #35) and the fleet template `reddoor-starter` (#23).

## Fix
Declare `sharp` as a direct `devDependency`, pinned `^0.33.5` (matches `imagetools-core`'s `sharp ^0.33.1`; single version). As a direct dep it resolves deterministically from root `node_modules`, independent of hoisting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)