### PR TITLE
chore(deps): bump @reddoorla/maintenance to ^0.65.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.60.0",
-    "@reddoorla/maintenance": "^0.58.0",
+    "@reddoorla/maintenance": "^0.65.0",
     "@slicemachine/adapter-sveltekit": "^0.3.96",
     "@sveltejs/adapter-netlify": "^6.0.4",
     "@sveltejs/kit": "^2.61.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
       '@reddoorla/maintenance':
-        specifier: ^0.58.0
-        version: 0.58.0(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))(jiti@2.7.0)(playwright-core@1.60.0)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
+        specifier: ^0.65.0
+        version: 0.65.0(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))(jiti@2.7.0)(playwright-core@1.60.0)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
       '@slicemachine/adapter-sveltekit':
         specifier: ^0.3.96
         version: 0.3.96(@prismicio/types@0.2.9)(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))(prettier-plugin-svelte@4.0.1(prettier@3.8.3)(svelte@5.55.10(@typescript-eslint/types@8.60.0)))(prettier@3.8.3)(svelte@5.55.10(@typescript-eslint/types@8.60.0))
@@ -622,8 +622,8 @@ packages:
     engines: {node: '>=12.7.0'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  '@reddoorla/maintenance@0.58.0':
-    resolution: {integrity: sha512-p0KHoRaLlIMJ9+4P6t5WhSjNHUU9VpM+TawvTzevxu9gEtjdz/yTDrS+WwqI2QtRaL3ik1x6dgOJTQPCcYqfXA==}
+  '@reddoorla/maintenance@0.65.0':
+    resolution: {integrity: sha512-omvrHLq2LcmWs4nue+Y4JvH27wpIOdoV93MAIl0xB0hJvuLM96wTcn6ujFzUHkyaVjmr7UW5+Dtn53n0uz5vlg==}
     engines: {node: '>=20'}
     hasBin: true
     peerDependencies:
@@ -3309,7 +3309,7 @@ snapshots:
   '@prismicio/types@0.2.9':
     optional: true
 
-  '@reddoorla/maintenance@0.58.0(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))(jiti@2.7.0)(playwright-core@1.60.0)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)':
+  '@reddoorla/maintenance@0.65.0(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.10(@typescript-eslint/types@8.60.0))(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.1)(jiti@2.7.0)))(jiti@2.7.0)(playwright-core@1.60.0)(svelte@5.55.10(@typescript-eslint/types@8.60.0))(typescript@6.0.3)':
     dependencies:
       '@axe-core/playwright': 4.11.3(playwright-core@1.60.0)
       '@eslint/js': 10.0.1(eslint@10.4.0(jiti@2.7.0))


### PR DESCRIPTION
Bumps `@reddoorla/maintenance` `^0.58.0` → `^0.65.0` (locked `0.65.0`).

0.65.0 is the first release past the **0.64 a11y-audit @libsql/client landmine** ([#330](https://github.com/reddoorla/reddoor-maintenance/pull/330)) — `reddoor-maint audit` no longer eager-imports the central-only libSQL/Kysely stack, so it runs cleanly on consuming sites (validated by the gallerysonder pilot's green CI). Moves this repo off the interim 0.58 pin onto the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)