### PR TITLE
fix(seo): render og:image + expose og tags + drop bad viewport

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,13 +34,12 @@
     <meta name="description" content={$page.data.meta_description} />
   {/if}
   {#if $page.data.meta_title}
-    <meta name="og:title" content={$page.data.meta_title} />
+    <meta property="og:title" content={$page.data.meta_title} />
   {/if}
   {#if $page.data.meta_image}
-    <meta name="og:image" content={$page.data.meta_image.url} />
+    <meta property="og:image" content={$page.data.meta_image} />
     <meta name="twitter:card" content="summary_large_image" />
   {/if}
-  <meta name="viewport" content="width=device-width, initial-scale=1.0 user-scalable=no" />
 </svelte:head>
 
 <svelte:window bind:innerWidth={viewportWidth} />


### PR DESCRIPTION
Three head bugs (same family as the rest of the fleet):

1. **og:image never rendered** — the load returns `meta_image` as a string, but the head did `.url` again → `undefined` content on every share.
2. **`name=` → `property=`** on og:title/og:image — OG scrapers ignore `name=` og tags.
3. Removed the duplicate, malformed viewport (`initial-scale=1.0 user-scalable=no` — missing comma + blocks pinch-zoom); `app.html` already ships `width=device-width`.

Markup-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)