### PR TITLE
feat: add /health endpoint (Report Health Gate function-health probe)

### DIFF
--- a/src/routes/health/+server.ts
+++ b/src/routes/health/+server.ts
@@ -1,0 +1,51 @@
+import { json } from "@sveltejs/kit";
+import { env as privateEnv } from "$env/dynamic/private";
+import { env as publicEnv } from "$env/dynamic/public";
+import * as prismicio from "$lib/prismicio";
+import type { RequestHandler } from "./$types";
+
+// A live probe — must never be prerendered.
+export const prerender = false;
+
+type PrismicHealth = "ok" | "error" | "skipped";
+
+type PrismicClient = { getRepository: () => Promise<unknown> };
+type PrismicModule = {
+  createClient?: (opts: { fetch: typeof globalThis.fetch }) => PrismicClient;
+  isPlaceholderRepo?: boolean;
+};
+
+// Server-side Prismic reachability probe. Hits the PUBLIC repository-metadata
+// endpoint (getRepository — no token), time-boxed, returning ONLY a status
+// string; the repository body is never included (/health is public).
+async function probePrismic(fetch: typeof globalThis.fetch): Promise<PrismicHealth> {
+  const mod = prismicio as PrismicModule;
+  const isPlaceholder = mod.isPlaceholderRepo ?? false;
+  if (isPlaceholder || typeof mod.createClient !== "function") return "skipped";
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const client = mod.createClient({ fetch });
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error("prismic health probe timed out")), 5000);
+    });
+    await Promise.race([client.getRepository(), timeout]);
+    return "ok";
+  } catch {
+    return "error";
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export const GET: RequestHandler = async ({ fetch }) => {
+  const prismic = await probePrismic(fetch);
+  const forms = {
+    ingestUrl: !!privateEnv.FORMS_INGEST_URL,
+    ingestToken: !!privateEnv.FORMS_INGEST_TOKEN,
+    turnstile: !!publicEnv.PUBLIC_TURNSTILE_SITE_KEY?.trim(),
+  };
+  // We're inside the handler, so the function ran; ok is false only when the
+  // Prismic probe actively errored.
+  const ok = prismic !== "error";
+  return json({ ok, prismic, forms });
+};


### PR DESCRIPTION
Adds `src/routes/health/+server.ts` — the `/health` probe the Report Health Gate's `function-health` audit fetches to verify Deploy & Function Health + CMS reachability.

Generated by the `health-endpoint` maintenance recipe ([reddoorla/reddoor-maintenance#371](https://github.com/reddoorla/reddoor-maintenance/pull/371)). The template namespace-imports `$lib/prismicio` and feature-detects `createClient`/`isPlaceholderRepo`, so it builds whether or not this site exports `isPlaceholderRepo` (validated on a real site with svelte-check). Noop-safe; no other files touched.

Once merged + deployed, the nightly `function-health` audit finds this site's `/health`, so its Maintenance report stops blocking on `unknown` and can auto-clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
