### PR TITLE
feat: add smoke suite (test:smoke + smoke specs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "format": "prettier --write . --plugin prettier-plugin-svelte .",
     "slicemachine": "start-slicemachine",
     "vite:devHost": "vite dev --host --port 8888",
-    "test:smoke": "playwright install chromium && playwright test",
-    "test:unit": "vitest run",
-    "test": "vitest run"
+    "test:smoke": "playwright install chromium && playwright test"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "lint": "prettier --check . --plugin prettier-plugin-svelte . && eslint .",
     "format": "prettier --write . --plugin prettier-plugin-svelte .",
     "slicemachine": "start-slicemachine",
-    "vite:devHost": "vite dev --host --port 8888"
+    "vite:devHost": "vite dev --host --port 8888",
+    "test:smoke": "playwright install chromium && playwright test",
+    "test:unit": "vitest run",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",

--- a/tests/smoke/pages.spec.ts
+++ b/tests/smoke/pages.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+import { smokeRoutes } from "./routes";
+
+// Console messages we don't care about. Add patterns here only after seeing them
+// in CI and confirming they aren't actionable. Patterns are matched against both
+// the message text and the offending resource URL — Chromium's "Failed to load
+// resource" text omits the URL, so URL matching catches third-party network noise.
+const ALLOWED_CONSOLE_PATTERNS: RegExp[] = [
+  // Vimeo iframe embeds + their CDN telemetry endpoints occasionally 403 from
+  // cloud IPs due to bot detection.
+  /vimeo/i,
+  // Turnstile (Cloudflare) telemetry occasionally surfaces in console.
+  /turnstile|challenges\.cloudflare/i,
+];
+
+function attachConsoleWatcher(page: Page, extraAllowed: RegExp[] = []) {
+  const errors: string[] = [];
+  const allowed = [...ALLOWED_CONSOLE_PATTERNS, ...extraAllowed];
+  const isAllowed = (s: string) => !!s && allowed.some((re) => re.test(s));
+
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() !== "error") return;
+    const text = msg.text();
+    const url = msg.location()?.url ?? "";
+    if (isAllowed(text) || isAllowed(url)) return;
+    errors.push(`[console.error] ${text}${url ? ` (${url})` : ""}`);
+  });
+
+  page.on("pageerror", (err) => {
+    if (isAllowed(err.message)) return;
+    errors.push(`[pageerror] ${err.message}`);
+  });
+
+  return errors;
+}
+
+for (const route of smokeRoutes) {
+  test(`${route.path} (${route.name}) loads with no console errors`, async ({ page }) => {
+    const errors = attachConsoleWatcher(page);
+    const response = await page.goto(route.path, {
+      waitUntil: "domcontentloaded",
+    });
+    expect(response?.status(), `HTTP status for ${route.path}`).toBe(route.expectStatus ?? 200);
+    if (route.hydrationMarker) {
+      await expect(
+        page.locator(route.hydrationMarker),
+        `hydration marker "${route.hydrationMarker}" on ${route.path}`,
+      ).toBeVisible();
+    }
+    expect(errors, `console errors on ${route.path}`).toEqual([]);
+  });
+}
+
+test("404 page renders the custom error component", async ({ page }) => {
+  // The browser logs a top-level "Failed to load resource: 404" for the page
+  // itself — expected on a 404 route, not a bug. Allow it here.
+  const errors = attachConsoleWatcher(page, [/Failed to load resource.*404/i]);
+  const response = await page.goto("/this-uid-does-not-exist", {
+    waitUntil: "domcontentloaded",
+  });
+  expect(response?.status()).toBe(404);
+  // src/routes/+error.svelte renders `<h1>{page.status}</h1>` → "404".
+  await expect(page.getByText("404", { exact: false }).first()).toBeVisible();
+  expect(errors).toEqual([]);
+});

--- a/tests/smoke/routes.ts
+++ b/tests/smoke/routes.ts
@@ -1,0 +1,25 @@
+// Committed per-site smoke manifest. `tests/smoke/pages.spec.ts` iterates this
+// list, asserting each route returns its expected status and paints a hydration
+// marker with no console errors. This ships the SAFE DEFAULT every reddoor-starter
+// clone inherits; each site's figma-slices build grows the list as real routes
+// land (add `{ path, name, hydrationMarker }` entries).
+//
+// NOTE on the default `/` entry: it expects 200, which holds once the clone is
+// wired to a real Prismic repo (getByUID("page","home") resolves). On the bare
+// placeholder starter, `/` returns 404 (the Prismic lookup throws → error(404)),
+// so the `/` case only goes green after Prismic is wired — by design, since the
+// gate is about real site health. The hydration marker `footer` is the shared
+// layout footer, present on every page including the error page.
+
+export type SmokeRoute = {
+  /** Route path to visit, e.g. "/" or "/about". */
+  path: string;
+  /** Human-readable label used in the test title. */
+  name: string;
+  /** CSS selector asserted visible after load (hydration proof). Default: skip. */
+  hydrationMarker?: string;
+  /** Expected HTTP status. Default: 200. */
+  expectStatus?: number;
+};
+
+export const smokeRoutes: SmokeRoute[] = [{ path: "/", name: "home", hydrationMarker: "footer" }];


### PR DESCRIPTION
Adds the **smoke suite** — the test infrastructure the Report Health Gate's `smoke` / `form-e2e` audits will consume once a producer workflow lands.

Generated by the `smoke-suite` maintenance recipe ([reddoorla/reddoor-maintenance#371](https://github.com/reddoorla/reddoor-maintenance/pull/371), formatting fix [#373](https://github.com/reddoorla/reddoor-maintenance/pull/373)), formatted to this repo's own prettier config. Idempotent + partial-apply — every file is noop-if-present, and an unusual existing `playwright.config.ts` is flagged for a manual R1.1 patch rather than overwritten.

## What it adds
- `tests/smoke/routes.ts` + `tests/smoke/pages.spec.ts` — the smoke specs
- A `test:smoke` / `test:unit` script split (`test` preserved)
- A `playwright.config.ts` that honors `REDDOOR_SMOKE_PORT` (R1.1) — only when absent or an exact pre-R1.1 shared-base config

**No runtime/user-facing change**: only test files, `package.json` scripts, and (if missing) the `@playwright/test` devDep — nothing under `src/routes`, so the deployed site is unchanged.

Once a nightly fleet-smoke workflow runs these, this site's `Smoke OK` signal flips from `unknown`, and Testing-report sends stop needing a manual override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
