### PR TITLE
fix: return 404 (not 500) for unknown pages

### DIFF
--- a/src/routes/[[preview=preview]]/[uid]/+page.server.js
+++ b/src/routes/[[preview=preview]]/[uid]/+page.server.js
@@ -1,19 +1,24 @@
 import { asText } from "@prismicio/client";
+import { error } from "@sveltejs/kit";
 
 import { createClient } from "$lib/prismicio";
 
 export async function load({ params, fetch, cookies }) {
   const client = createClient({ fetch, cookies });
 
-  const page = await client.getByUID("page", params.uid);
+  try {
+    const page = await client.getByUID("page", params.uid);
 
-  return {
-    page,
-    title: asText(page.data.title),
-    meta_description: page.data.meta_description,
-    meta_title: page.data.meta_title,
-    meta_image: page.data.meta_image.url,
-  };
+    return {
+      page,
+      title: asText(page.data.title),
+      meta_description: page.data.meta_description,
+      meta_title: page.data.meta_title,
+      meta_image: page.data.meta_image.url,
+    };
+  } catch {
+    error(404, { message: "Page not found" });
+  }
 }
 
 export async function entries() {


### PR DESCRIPTION
Unknown URLs (e.g. `/this-does-not-exist`) were returning **HTTP 500** instead of 404: the `[uid]` catch-all's `load` called `client.getByUID()` with no error handling, so Prismic's `NotFoundError` propagated uncaught.

Fix: wrap in `try/catch` and `error(404, …)` on miss — the canonical pattern the starter (and revogen/sonder) already use. Dead links now 404, which is correct for SEO/UX and clears the fleet smoke suite's not-found check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)