### PR TITLE
feat(seo): add Prismic-backed sitemap.xml

### DIFF
--- a/src/lib/site.js
+++ b/src/lib/site.js
@@ -1,0 +1,5 @@
+// Single source of truth for the site's canonical origin. Import this anywhere
+// a fully-qualified caltexmedical.com URL is needed (sitemap, canonical tags,
+// og:url, JSON-LD) so the origin can never drift out of lockstep. The live site
+// is served from the www host.
+export const SITE_URL = "https://www.caltexmedical.com";

--- a/src/routes/sitemap.xml/+server.js
+++ b/src/routes/sitemap.xml/+server.js
@@ -1,0 +1,57 @@
+import { createClient } from "$lib/prismicio";
+// The canonical origin lives in a single $lib constant so the sitemap stays in
+// lockstep with the rest of the site. Never re-hardcode the host here — a
+// duplicated origin is exactly how a sister site drifted onto a stale www.
+import { SITE_URL } from "$lib/site";
+
+// Prerendered alongside the rest of the site, so Netlify serves it as a static
+// file at /sitemap.xml.
+export const prerender = true;
+
+// Fixed page routes under src/routes/[[preview=preview]]/. The `home` singleton
+// renders at "/"; leasing/purchases/community/contact are static page routes.
+const STATIC_PATHS = ["/", "/leasing", "/purchases", "/community", "/contact"];
+
+// Repeatable Prismic document type -> public path. The `home` type is a
+// singleton served at "/" (covered by STATIC_PATHS); only `page` docs are
+// dynamic. Keep in sync with the route folders under [[preview=preview]]/.
+/** @type {Record<string, (uid: string) => string>} */
+const TYPE_PATHS = {
+  page: (uid) => `/${uid}`,
+};
+
+export async function GET({ fetch }) {
+  const client = createClient({ fetch });
+  const docs = await client.dangerouslyGetAll().catch(() => []);
+
+  const seen = new Set();
+  const urls = [];
+
+  const push = (path, lastmod) => {
+    if (seen.has(path)) return;
+    seen.add(path);
+    const loc = SITE_URL + path;
+    urls.push(
+      `\t<url>\n\t\t<loc>${loc}</loc>${lastmod ? `\n\t\t<lastmod>${lastmod}</lastmod>` : ""}\n\t</url>`,
+    );
+  };
+
+  // Static routes first (no honest per-page lastmod — they render shared data).
+  for (const path of STATIC_PATHS) push(path);
+
+  // Then every repeatable page document, keyed by its uid.
+  for (const doc of docs) {
+    const build = TYPE_PATHS[doc.type];
+    if (!build || !doc.uid) continue;
+    push(build(doc.uid), doc.last_publication_date?.slice(0, 10));
+  }
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join("\n")}
+</urlset>`;
+
+  return new Response(body, {
+    headers: { "Content-Type": "application/xml" },
+  });
+}

--- a/src/routes/sitemap.xml/+server.js
+++ b/src/routes/sitemap.xml/+server.js
@@ -24,9 +24,12 @@ export async function GET({ fetch }) {
   const client = createClient({ fetch });
   const docs = await client.dangerouslyGetAll().catch(() => []);
 
+  /** @type {Set<string>} */
   const seen = new Set();
+  /** @type {string[]} */
   const urls = [];
 
+  /** @param {string} path @param {string} [lastmod] */
   const push = (path, lastmod) => {
     if (seen.has(path)) return;
     seen.add(path);

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow:
+
+Sitemap: https://www.caltexmedical.com/sitemap.xml


### PR DESCRIPTION
## What

Adds a prerendered `/sitemap.xml` route (`src/routes/sitemap.xml/+server.js`) backed by Prismic, following the fleet reference pattern (gallerysonder's sitemap route).

## Routes / types covered

Static page routes (from `src/routes/[[preview=preview]]/`, confirmed against the nav in `+layout.svelte`):

- `/` — the `home` singleton
- `/leasing`
- `/purchases`
- `/community`
- `/contact`

Dynamic Prismic docs:

- `page` (repeatable) → `/<uid>`, enumerated via `client.dangerouslyGetAll()` and mapped through a `TYPE_PATHS` table, with `<lastmod>` populated from `last_publication_date` when present.

Excluded: the `home` singleton is emitted once as `/` (it has no uid); no settings/demo/test types exist to filter.

## Entry count

**5 URLs** at build time — the five static routes. There are currently **no published `page` documents** in Prismic, so the dynamic branch yields zero today; it is wired and will pick up `page` docs automatically as they're published (deduped against the static paths).

## Canonical origin

The repo had **no** existing site-URL constant (`$lib/index.js` was empty). Added `src/lib/site.js` exporting `SITE_URL = "https://www.caltexmedical.com"` and imported it into the sitemap route rather than hardcoding the host, mirroring the reference's single-source-of-truth guard against stale-`www` drift. Also added a `Sitemap:` line to `static/robots.txt`.

## Verified

- `pnpm install` + `pnpm build` succeed; Prismic fetch during prerender succeeded (home/leasing/purchases/community/contact all prerendered from live data).
- `/sitemap.xml` is present in the prerendered output (`build/sitemap.xml`, `.svelte-kit/output/prerendered/pages/sitemap.xml`) — valid `<urlset>` XML, `Content-Type: application/xml`, 5 `<loc>` entries.
- `pnpm lint` (prettier + eslint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)