### PR TITLE
fix(seo): always emit meta description with honest layout fallback

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,13 +26,16 @@
   let showNav = $state(false);
 
   let content = $derived(data.page.data);
+
+  // Fallback only — a non-empty per-page Prismic meta_description always wins.
+  // Copy taken verbatim from the live homepage subtitle.
+  const DEFAULT_DESCRIPTION =
+    "Caltex Medical: AEDs and program management currently serving the Texas Hill Country and San Antonio area.";
 </script>
 
 <svelte:head>
   <title>{$page.data.title}</title>
-  {#if $page.data.meta_description}
-    <meta name="description" content={$page.data.meta_description} />
-  {/if}
+  <meta name="description" content={$page.data.meta_description || DEFAULT_DESCRIPTION} />
   {#if $page.data.meta_title}
     <meta property="og:title" content={$page.data.meta_title} />
   {/if}


### PR DESCRIPTION
## Audit failure

Nightly fleet audit "Titles & Meta OK: **fail**" — every crawled route (`/`, `/leasing`, `/purchases`, `/community`, `/contact`, and the dynamic `[uid]` pages) ships **no `<meta name="description">` at all**. Root cause: every `+page.server.js` load already passes `meta_description` through from Prismic, but the Prismic field is empty on the home document, and the layout only rendered the tag inside an `{#if $page.data.meta_description}` guard — so the tag was dropped site-wide.

## Change

`src/routes/+layout.svelte` (same pattern as the MSOT/ERP/Espada/Revogen/Vineyard meta-fallback wave):

- Emit `<meta name="description">` **unconditionally** in `<svelte:head>`.
- A non-empty per-page Prismic `meta_description` always wins (`$page.data.meta_description || DEFAULT_DESCRIPTION`); the fallback fires only when the Prismic value is empty/missing — no editable content is overridden.
- `DEFAULT_DESCRIPTION` is honest copy taken verbatim from the live homepage subtitle: *"Caltex Medical: AEDs and program management currently serving the Texas Hill Country and San Antonio area."*

No load-function changes needed — all loads (layout, static pages, `[uid]`) already return `meta_description`.

## Verification

- `pnpm install` — clean (frozen lockfile)
- `pnpm lint` — prettier + eslint pass
- `pnpm check` — svelte-check (checkJs): **0 errors, 0 warnings** (4231 files)
- `pnpm build` — succeeds; grepped `.svelte-kit/output/prerendered/pages/*.html`: all 6 prerendered pages (`index`, `leasing`, `purchases`, `community`, `contact`, `dev/a11y-fixtures`) now contain the non-empty `<meta name="description">`. No `page`-type docs exist in Prismic yet, so no `[uid]` routes prerender; that route uses the same layout head and gets the same fallback at SSR time.

## Operator note

To get per-page descriptions instead of the site-wide fallback, fill the `meta_description` field on the Prismic `home` document (and any future `page` documents) — those values now render as-is and take precedence automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)