### PR TITLE
chore(deps): update actions/checkout to v7

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,7 +7,7 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: renovatebot/github-action@1a96852b0384df1837619d04c60b2d10d1f9ff08 # v46.1.21
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
Updates `actions/checkout` to v7 in `.github/workflows/renovate.yml` — the only `actions/checkout` reference in this repo (`ci.yml` is a thin caller into the shared `reddoorla/.github` reusable workflow, which pins its own checkout).

Pinned to `3d3c42e5aac5ba805825da76410c181273ba90b1`, verified against `actions/checkout`'s own `git/ref/tags/v7` (v7.0.1, 2026-07-17). Digest-plus-`# v7` comment shape preserved for `helpers:pinGitHubActionDigests`.

Supersedes #36, the stale Renovate PR for this update. That PR conflicts with `main` and cannot be rebased: `main` has since moved the adjacent `renovatebot/github-action` pin to v46.1.21, so the branch's hunk no longer applies and GitHub's update-branch API refuses with "merge conflict between base and head". Rebuilding the change on current `main` is the cleanest path. #36 can be closed as superseded.

Note: #36 proposed the older `9c091bb2…` (v7.0.0) digest; this PR lands the current v7 tag instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
