### PR TITLE
chore(ci): run renovate twice daily

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,7 @@
 name: renovate
 on:
   schedule:
-    - cron: "0 7 * * 1"
+    - cron: "0 */12 * * *"
   workflow_dispatch:
 jobs:
   renovate:


### PR DESCRIPTION
Moves the Renovate workflow from a weekly cron to a twice-daily one.

## Why

GitHub platform auto-merge has been disabled across all org repos, and the shared Renovate preset now sets `platformAutomerge: false`. Renovate therefore performs its merges from **inside its own run** instead of handing GitHub a flag to fire later. That is the point of the change: Renovate's own `packageRules` — which forbid auto-merging majors — become the actual decision-maker, rather than GitHub firing a merge on any PR that happens to go green.

The consequence is that **Renovate can only merge while it is running**. This workflow's cron is therefore now the fleet's *merge* cadence, not just its PR-creation cadence. On the previous weekly schedule (`0 7 * * 1`) a green patch/minor update could sit unmerged for up to seven days.

## Change

The schedule in `.github/workflows/renovate.yml` goes from `0 7 * * 1` to `0 */12 * * *` — twice daily replaces weekly. That one line is the entire diff; the file's existing quote style is preserved and nothing else in the workflow is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
