### PR TITLE
fix(seo): give each page a distinct document title

### DIFF
--- a/src/routes/[[preview=preview]]/community/+page.server.js
+++ b/src/routes/[[preview=preview]]/community/+page.server.js
@@ -7,7 +7,7 @@ export async function load({ fetch, cookies }) {
 
   return {
     page,
-    title: "Caltex Medical",
+    title: "Grants & Community | Caltex Medical",
     meta_description: page.data.meta_description,
     meta_title: page.data.meta_title,
     meta_image: page.data.meta_image.url,

--- a/src/routes/[[preview=preview]]/contact/+page.server.js
+++ b/src/routes/[[preview=preview]]/contact/+page.server.js
@@ -7,7 +7,7 @@ export async function load({ fetch, cookies }) {
 
   return {
     page,
-    title: "Caltex Medical",
+    title: "Contact Us | Caltex Medical",
     meta_description: page.data.meta_description,
     meta_title: page.data.meta_title,
     meta_image: page.data.meta_image.url,

--- a/src/routes/[[preview=preview]]/leasing/+page.server.js
+++ b/src/routes/[[preview=preview]]/leasing/+page.server.js
@@ -7,7 +7,7 @@ export async function load({ fetch, cookies }) {
 
   return {
     page,
-    title: "Caltex Medical",
+    title: "AED Leasing | Caltex Medical",
     meta_description: page.data.meta_description,
     meta_title: page.data.meta_title,
     meta_image: page.data.meta_image.url,

--- a/src/routes/[[preview=preview]]/purchases/+page.server.js
+++ b/src/routes/[[preview=preview]]/purchases/+page.server.js
@@ -7,7 +7,7 @@ export async function load({ fetch, cookies }) {
 
   return {
     page,
-    title: "Caltex Medical",
+    title: "AED Purchases | Caltex Medical",
     meta_description: page.data.meta_description,
     meta_title: page.data.meta_title,
     meta_image: page.data.meta_image.url,


### PR DESCRIPTION
## Why

The fleet audit's **Titles & Meta OK** check is failing for CalTex: all five sitemap routes (`/`, `/leasing`, `/purchases`, `/community`, `/contact`) serve the identical `<title>Caltex Medical</title>`, tripping the audit's duplicate-title rule — and reading as one page to search engines.

Root cause: every static sub-page's `+page.server.js` hardcodes `title: "Caltex Medical"`.

## What

Each sub-page now titles itself after its own h1, keeping the ` | Caltex Medical` suffix (all ≤ 70 chars, per the audit's length rule). The homepage keeps the bare brand title.

- `/leasing` → **AED Leasing | Caltex Medical**
- `/purchases` → **AED Purchases | Caltex Medical**
- `/community` → **Grants & Community | Caltex Medical**
- `/contact` → **Contact Us | Caltex Medical**

Meta descriptions are untouched — the audit only forbids duplicate titles, and the per-page Prismic `meta_description` fallback already passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)