### PR TITLE
test(prismic): prove headless model delivery end-to-end

### DIFF
--- a/customtypes/page/index.json
+++ b/customtypes/page/index.json
@@ -22,6 +22,15 @@
           "single": "heading1"
         }
       },
+      "delivery_probe": {
+        "type": "Boolean",
+        "config": {
+          "label": "Delivery probe (temporary)",
+          "placeholder_false": "off",
+          "placeholder_true": "on",
+          "default_value": false
+        }
+      },
       "slices": {
         "type": "Slices",
         "fieldset": "Slice Zone",


### PR DESCRIPTION
**Temporary — will be reverted immediately after it proves the path.**

Adds one Boolean field, `Main.delivery_probe`, to the `page` custom type. Purely additive, referenced by no component, and invisible on the rendered site.

This is Task 32 steps 3–4 of the headless Prismic model-delivery plan: the end-to-end proof, against a real repository, that

1. the `prismic-models` check comments the delta on the PR, and
2. merging pushes it to Prismic with no human step beyond the merge.

Local dry run before pushing:

```
DRY RUN — nothing was sent. 1 model(s) would be pushed; 5 already match.
CHANGED  customtype page  (customtypes/page/index.json)
    + Main.delivery_probe
```

CalTex was chosen because it is the smallest model surface on the fleet (6 models) and was exactly in sync beforehand, so this PR pushes one field and nothing else. A follow-up PR removes the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
