### PR TITLE
revert(prismic): remove the temporary delivery-proof field

### DIFF
--- a/customtypes/page/index.json
+++ b/customtypes/page/index.json
@@ -22,15 +22,6 @@
           "single": "heading1"
         }
       },
-      "delivery_probe": {
-        "type": "Boolean",
-        "config": {
-          "label": "Delivery probe (temporary)",
-          "placeholder_false": "off",
-          "placeholder_true": "on",
-          "default_value": false
-        }
-      },
       "slices": {
         "type": "Slices",
         "fieldset": "Slice Zone",


### PR DESCRIPTION
Removes `Main.delivery_probe` from the `page` custom type, restoring CalTex to its pre-proof state. Reverts #54.

The field existed for roughly ten minutes, was referenced by no component, and no document ever used it — so nothing is lost by dropping it.

**The `prismic-models` check will flag this as DESTRUCTIVE, and that is correct.** Removing a field from a live model is exactly the class of change the warning exists for; it is safe here only because the field is brand new and unused:

```
⚠ DESTRUCTIVE — 1 line(s) below remove a field, variation, or tab from a live model.
CHANGED  customtype page  (customtypes/page/index.json)
    - Main.delivery_probe (only in Prismic — pushing DELETES it)
```

Merging this completes Task 32: the delivery path was proven in both directions — a field added on merge, and removed on merge — against a real repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
