### PR TITLE
ci: run on pushes to staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, staging]
 jobs:
   ci:
     permissions:


### PR DESCRIPTION
Adds `staging` to the CI push triggers.

`pull_request:` has no branch filter, so it already covers PRs against any branch. The hole is a **direct push to staging** — it opens no PR, so nothing runs, and a spec living only on a feature branch stays unverified until its eventual PR to `main`.

That is not hypothetical: a timezone-dependent assertion in reddoor-website's `inquiry-modal.spec.ts` passed on every local machine and failed the first time CI ever saw it, at the release PR.

Inert in a repo with no staging branch — the trigger simply never fires. It is here so the gap cannot reopen the day someone creates one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)