### PR TITLE
ci: take reusable workflow v1.4.1 (single smoke run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: reddoorla/.github/.github/workflows/ci.yml@4a32c3d0caf2050d6f72274d3325f2306772860d # v1.3.0
+    uses: reddoorla/.github/.github/workflows/ci.yml@8f9852c4f69f629d1d785036366d74d9358645f9 # v1.4.1
     with:
       node-version: "24"


### PR DESCRIPTION
Takes reusable workflow **v1.4.1** ([reddoorla/.github#31](https://github.com/reddoorla/.github/pull/31)), a 3-version jump from v1.3.0.

What changes in the consumed `ci.yml`:

- **Smoke suite no longer runs twice per PR.** The `Test (if present)` step runs `pnpm test`, which on most sites already chains `test:smoke`; the separate smoke step then re-ran the whole Playwright suite. It now skips when `test` already chains it — a condition, not a deletion, so a site with `test:smoke` and no `test` script still gets that step. Both branches were verified on real runners before this sweep: gallerysonder ran its 79 smoke tests via the step, the-pointe-burbank ran its 12 once and skipped the duplicate.
- `actions/checkout` v6 → **v7**, `actions/setup-node` v6 → **v7**, `pnpm/action-setup` 6.0.9 → 6.0.10 (these landed in v1.4.0, which no repo had picked up).

Nothing propagates this pin — `ci.yml` is deliberately outside `sync-configs`, and Renovate has never opened a PR for it — so every fleet repo sat on v1.3.0 for 18 days after v1.4.0 shipped. This is the sweep.

Only the `uses:` line changes; merging on green only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)