### PR TITLE
fix(images): cap Prismic srcset widths and give every image a real sizes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.60.0",
-    "@reddoorla/maintenance": "^0.83.0",
+    "@reddoorla/maintenance": "^0.90.0",
     "@slicemachine/adapter-sveltekit": "^0.3.96",
     "@sveltejs/adapter-netlify": "^6.0.4",
     "@sveltejs/kit": "^2.61.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ importers:
         specifier: ^1.60.0
         version: 1.62.1
       '@reddoorla/maintenance':
-        specifier: ^0.83.0
-        version: 0.83.0(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.10(@typescript-eslint/types@8.67.0))(vite@8.2.2(@types/node@25.9.5)(jiti@2.7.0)))(svelte@5.56.10(@typescript-eslint/types@8.67.0))(typescript@6.0.3)(vite@8.2.2(@types/node@25.9.5)(jiti@2.7.0)))(jiti@2.7.0)(playwright-core@1.62.1)(svelte@5.56.10(@typescript-eslint/types@8.67.0))(typescript@6.0.3)
+        specifier: ^0.90.0
+        version: 0.90.1(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.10(@typescript-eslint/types@8.67.0))(vite@8.2.2(@types/node@25.9.5)(jiti@2.7.0)))(svelte@5.56.10(@typescript-eslint/types@8.67.0))(typescript@6.0.3)(vite@8.2.2(@types/node@25.9.5)(jiti@2.7.0)))(jiti@2.7.0)(playwright-core@1.62.1)(svelte@5.56.10(@typescript-eslint/types@8.67.0))(typescript@6.0.3)
       '@slicemachine/adapter-sveltekit':
         specifier: ^0.3.96
         version: 0.3.98(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.10(@typescript-eslint/types@8.67.0))(vite@8.2.2(@types/node@25.9.5)(jiti@2.7.0)))(svelte@5.56.10(@typescript-eslint/types@8.67.0))(typescript@6.0.3)(vite@8.2.2(@types/node@25.9.5)(jiti@2.7.0)))(prettier-plugin-svelte@4.1.1(prettier@3.9.6)(svelte@5.56.10(@typescript-eslint/types@8.67.0)))(prettier@3.9.6)(svelte@5.56.10(@typescript-eslint/types@8.67.0))
@@ -721,8 +721,8 @@ packages:
       io-ts: ^2.2.16
       io-ts-types: ^0.5.16
 
-  '@reddoorla/maintenance@0.83.0':
-    resolution: {integrity: sha512-mF8Bo3JeCdzowuSqaBFEyYcL93lMfCgXs+4apzIP/rNWqj5RDqDXYzqzZZDWNt5lnNJ3oiqMFrmGNtSrMB9nXg==}
+  '@reddoorla/maintenance@0.90.1':
+    resolution: {integrity: sha512-LPjO1GGC3o+P3o/NNYQow0J0wFSrJACK0x7dYqhlkjE6/qNq8roQw9wKg+LqeWlaam2tAB08hKzeGkf1/NzQow==}
     engines: {node: '>=20'}
     hasBin: true
     peerDependencies:
@@ -3410,7 +3410,7 @@ snapshots:
       tslib: 2.8.1
       uuid: 11.1.1
 
-  '@reddoorla/maintenance@0.83.0(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.10(@typescript-eslint/types@8.67.0))(vite@8.2.2(@types/node@25.9.5)(jiti@2.7.0)))(svelte@5.56.10(@typescript-eslint/types@8.67.0))(typescript@6.0.3)(vite@8.2.2(@types/node@25.9.5)(jiti@2.7.0)))(jiti@2.7.0)(playwright-core@1.62.1)(svelte@5.56.10(@typescript-eslint/types@8.67.0))(typescript@6.0.3)':
+  '@reddoorla/maintenance@0.90.1(@sveltejs/kit@2.70.3(@sveltejs/vite-plugin-svelte@7.3.0(svelte@5.56.10(@typescript-eslint/types@8.67.0))(vite@8.2.2(@types/node@25.9.5)(jiti@2.7.0)))(svelte@5.56.10(@typescript-eslint/types@8.67.0))(typescript@6.0.3)(vite@8.2.2(@types/node@25.9.5)(jiti@2.7.0)))(jiti@2.7.0)(playwright-core@1.62.1)(svelte@5.56.10(@typescript-eslint/types@8.67.0))(typescript@6.0.3)':
     dependencies:
       '@axe-core/playwright': 4.13.0(playwright-core@1.62.1)
       '@eslint/js': 10.0.1(eslint@10.9.0(jiti@2.7.0))

--- a/src/lib/components/ScreenWidth/ScreenWidthImage.svelte
+++ b/src/lib/components/ScreenWidth/ScreenWidthImage.svelte
@@ -4,6 +4,7 @@
   import placeholder from "../../assets/images/background_placeholder.svg";
   import ContentWidth from "../ContentWidth/ContentWidth.svelte";
   import { PrismicImage } from "@prismicio/svelte";
+  import { cappedWidths } from "@reddoorla/maintenance/images";
 
   interface Props {
     src?: string;
@@ -62,6 +63,8 @@
     {:else}
       <PrismicImage
         {field}
+        widths={cappedWidths(field)}
+        sizes="100vw"
         loading={priority ? "eager" : "lazy"}
         fetchpriority={priority ? "high" : "auto"}
         decoding="async"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,6 +13,7 @@
   import { Menu } from "@lucide/svelte";
   import { requestModal } from "$lib/stores/requestModal.svelte";
   import { CONTACT } from "$lib/constants/contact";
+  import { cappedWidths } from "@reddoorla/maintenance/images";
 
   /**
    * @typedef {Object} Props
@@ -52,6 +53,11 @@
       <a href="/" onclick={() => (showNav = false)}>
         <PrismicImage
           field={viewportWidth > 768 ? content.logo : content.logo_mark}
+          widths={cappedWidths(
+            viewportWidth > 768 ? content.logo : content.logo_mark,
+            [160, 320, 480],
+          )}
+          sizes="(min-width: 768px) 220px, 80px"
           loading="eager"
           fetchpriority="high"
           class="w-auto h-10"
@@ -109,6 +115,11 @@
         <a href="/" onclick={() => (showNav = false)}>
           <PrismicImage
             field={viewportWidth > 768 ? content.logo : content.logo_mark}
+            widths={cappedWidths(
+              viewportWidth > 768 ? content.logo : content.logo_mark,
+              [160, 320, 480],
+            )}
+            sizes="(min-width: 768px) 220px, 80px"
             loading="lazy"
             class="w-auto h-10"
           />

--- a/src/routes/[[preview=preview]]/+page.svelte
+++ b/src/routes/[[preview=preview]]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
   import { PrismicImage } from "@prismicio/svelte";
+  import { cappedWidths } from "@reddoorla/maintenance/images";
 
   let { data, ..._rest } = $props();
   let content = $derived(data.page.data);
@@ -12,12 +13,16 @@
     <PrismicImage
       class="w-3/5 pb-4 -translate-x-[20%] hidden xs:block md:hidden"
       field={content.aed}
+      widths={cappedWidths(content.aed)}
+      sizes="53vw"
       loading="eager"
       fetchpriority="high"
     />
     <PrismicImage
       class="md:w-2/3 mb-48 md:mb-64"
       field={content.s1_title}
+      widths={cappedWidths(content.s1_title)}
+      sizes="(min-width: 768px) 59vw, 88vw"
       loading="eager"
       fetchpriority="high"
     />
@@ -29,6 +34,8 @@
     <PrismicImage
       class="absolute bottom-8 right-0 w-1/2 translate-x-[20%] hidden md:block"
       field={content.aed}
+      widths={cappedWidths(content.aed)}
+      sizes="44vw"
       loading="eager"
       fetchpriority="high"
     />
@@ -61,6 +68,9 @@ from `$lib/stores/requestModal.svelte`.
             <PrismicImage
               class="w-full h-full  absolute top-0 left-0 blur-sm brightness-75"
               field={block.image}
+              widths={cappedWidths(block.image)}
+              sizes="(min-width: 768px) 44vw, 88vw"
+              loading="lazy"
             />
             <h4 class="z-10 lg:w-1/2">{block.title}</h4>
             <p class="z-10">{block.body}</p>
@@ -115,6 +125,9 @@ from `$lib/stores/requestModal.svelte`.
             >
               <PrismicImage
                 field={step.number}
+                widths={cappedWidths(step.number, [160, 320, 480])}
+                sizes="(min-width: 768px) 160px, 120px"
+                loading="lazy"
                 class="h-3/5 md:h-4/5 xl:h-full"
               />
             </div>

--- a/src/routes/[[preview=preview]]/community/+page.svelte
+++ b/src/routes/[[preview=preview]]/community/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
   import { PrismicImage, PrismicRichText } from "@prismicio/svelte";
+  import { cappedWidths } from "@reddoorla/maintenance/images";
 
   let { data, ..._rest } = $props();
   let content = $derived(data.page.data);
@@ -13,10 +14,19 @@
 <section id="s8" class="w-screen bg-primary text-white mt-24 py-16 md:py-24 -mb-48 relative">
   <ContentWidth class="flex flex-col md:flex-row">
     <div class="w-full md:w-1/2 flex flex-col items-start md:pr-5">
-      <PrismicImage class="w-full" field={content.s8_title} loading="eager" fetchpriority="high" />
+      <PrismicImage
+        class="w-full"
+        field={content.s8_title}
+        widths={cappedWidths(content.s8_title)}
+        sizes="(min-width: 768px) 44vw, 88vw"
+        loading="eager"
+        fetchpriority="high"
+      />
       <PrismicImage
         class="w-2/3 -translate-x-[20%]"
         field={content.s8_aed}
+        widths={cappedWidths(content.s8_aed)}
+        sizes="(min-width: 768px) 29vw, 59vw"
         loading="eager"
         fetchpriority="high"
       />

--- a/src/routes/[[preview=preview]]/contact/+page.svelte
+++ b/src/routes/[[preview=preview]]/contact/+page.svelte
@@ -2,6 +2,7 @@
   import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
   import { PrismicImage, PrismicRichText } from "@prismicio/svelte";
   import { CONTACT } from "$lib/constants/contact";
+  import { cappedWidths } from "@reddoorla/maintenance/images";
   let { data, ..._rest } = $props();
   let content = $derived(data.page.data);
 </script>
@@ -14,6 +15,8 @@
   <PrismicImage
     class="absolute h-[100vw] w-screen top-0 right-[4vw] lg:top-[5vw] lg:left-0 lg:h-[40vw] lg:w-[40vw] rounded-r-lg"
     field={content.s7_image}
+    widths={cappedWidths(content.s7_image)}
+    sizes="(min-width: 1024px) 40vw, 100vw"
     loading="eager"
     fetchpriority="high"
   />

--- a/src/routes/[[preview=preview]]/leasing/+page.svelte
+++ b/src/routes/[[preview=preview]]/leasing/+page.svelte
@@ -2,6 +2,7 @@
   import ContentWidth from "$lib/components/ContentWidth/ContentWidth.svelte";
   import { PrismicImage } from "@prismicio/svelte";
   import ScreenWidthImage from "$lib/components/ScreenWidth/ScreenWidthImage.svelte";
+  import { cappedWidths } from "@reddoorla/maintenance/images";
 
   let { data, ..._rest } = $props();
   let content = $derived(data.page.data);
@@ -22,6 +23,8 @@
     <PrismicImage
       class="w-full md:w-3/5"
       field={content.s5_title}
+      widths={cappedWidths(content.s5_title)}
+      sizes="(min-width: 768px) 53vw, 88vw"
       loading="eager"
       fetchpriority="high"
     />
@@ -36,7 +39,13 @@
           <div
             class="h-40 md:h-52 w-full bg-white text-primary flex flex-row justify-between items-center rounded-[7px] p-11 gap-11"
           >
-            <PrismicImage class="w-32 h-32" field={icon.icon} />
+            <PrismicImage
+              class="w-32 h-32"
+              field={icon.icon}
+              widths={cappedWidths(icon.icon, [128, 256, 384])}
+              sizes="128px"
+              loading="lazy"
+            />
             <h3>{icon.label}</h3>
           </div>
         </div>

--- a/src/routes/[[preview=preview]]/purchases/+page.svelte
+++ b/src/routes/[[preview=preview]]/purchases/+page.svelte
@@ -3,6 +3,7 @@
   import { PrismicImage } from "@prismicio/svelte";
   import DefaultButton from "$lib/components/Buttons/DefaultButton.svelte";
   import { requestModal } from "$lib/stores/requestModal.svelte";
+  import { cappedWidths } from "@reddoorla/maintenance/images";
 
   let { data, ..._rest } = $props();
   let content = $derived(data.page.data);
@@ -16,6 +17,8 @@
   <PrismicImage
     class="absolute h-[100vw] w-screen top-0 right-[4vw] lg:top-[5vw] lg:left-0 lg:h-[40vw] lg:w-[40vw] rounded-r-lg"
     field={content.s3_image}
+    widths={cappedWidths(content.s3_image)}
+    sizes="(min-width: 1024px) 40vw, 100vw"
     loading="eager"
     fetchpriority="high"
   />


### PR DESCRIPTION
## Why

`<PrismicImage>` advertises every default srcset width (up to `3840w`) regardless of how big the source asset is, and with no `sizes` attribute the browser assumes `100vw` — so it picks those top candidates and Prismic upscales on demand. Those variants are always a cache MISS, are expensive to generate, and surface as **slow or failed images in production** while the same asset's smaller variants serve fine.

This came out of a "some photos don't load" report on revogen ([revogen#69](https://github.com/reddoorla/revogen/pull/69)). A fleet audit found the same gap in 14 of 15 Prismic sites — 158 call sites — inherited from both starters, now fixed upstream ([starter#109](https://github.com/reddoorla/reddoor-starter/pull/109), [blux#5](https://github.com/reddoorla/reddoor-starter-blux/pull/5)).

Measured on a live fleet page (`vineyardconstruction.com/gallery/modern-warmth`, 1440px desktop): every image downloaded the `2048w` candidate while rendering at 638–1311 CSS px. **2.82 MB shipped vs 1.97 MB needed — 30% of image bytes wasted**, more on mobile.

## What changed

- **`widths={cappedWidths(field)}`** from `@reddoorla/maintenance/images` trims candidates to the image's own pixel width. Mechanical — no layout knowledge needed, and since upscaling adds no detail the render is unchanged.
- **`sizes` per slot** — the half only the site can know, measured from each container.
- `loading="lazy"` below the fold, `fetchpriority="high"` on full-bleed backdrops (usually the LCP element).
- `@reddoorla/maintenance` bumped to `^0.90.0` for the new subpath.

**No visual change.** Upscaling adds no detail, so a capped srcset renders identically — this is a pure payload reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
