### PR TITLE
docs: adopt the work-journal convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,4 +65,12 @@ journal is a record of what was believed at the time, and that record is most
 useful precisely where it was wrong. Fixing the past in place destroys the only
 evidence of how the mistake was made.
 
+The one edit an old entry may take is a **forward pointer**: one line directly
+under its heading naming the entry that overturned it — `> Superseded in part by
+2026-10-14 — <that entry's title>.` It asserts nothing new and retracts nothing,
+so the record of what was believed survives whole; it only stops a reader who
+lands on the old paragraph from leaving with the old answer. Without it the rule
+above is half a mechanism: the correction exists at the bottom of the file, and
+nothing points to it from where a reader actually arrives.
+
 If a session produced nothing worth an entry, that is itself worth one line.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+The marketing site for **Caltex Medical** — AEDs, leasing and program
+management for San Antonio and the Texas Hill Country. SvelteKit 2 / Svelte 5 /
+Tailwind v4 / Prismic (`caltex-landing`), deployed on Netlify at
+`https://www.caltexmedical.com`. Source is in `src/`: five hand-built routes
+under `src/routes/[[preview=preview]]/` (home, community, leasing, purchases,
+contact) plus a Prismic `[uid]` catch-all, and four slices in
+`src/lib/slices/`.
+
+There is no `pnpm verify` here. The checks are `pnpm lint`, `pnpm check`,
+`pnpm build` and `pnpm test:smoke`; CI runs the shared reusable workflow from
+`reddoorla/.github`.
+
+Three things that are not obvious:
+
+- **`README.md` describes the wireframer starter this was forked from, not this
+  site.** It has never been rewritten. Treat it as history.
+- **The lint/format/test configs are owned by `@reddoorla/maintenance`** and
+  overwritten by `sync-configs` — `eslint.config.js`, `.prettierrc.json`,
+  `lighthouserc.json`, `playwright.config.ts`, `svelte.config.js`. Change them
+  there, not here. See [docs/UPGRADE_NOTES.md](docs/UPGRADE_NOTES.md).
+- **Public contact details live in `src/lib/constants/contact.ts`**, one export,
+  imported everywhere. The client's name was once hand-copied wrong into five
+  files; that constant is the fix, so do not inline it again.
+
+## The work journal
+
+**Every working session appends a dated entry to `docs/workJournal.md`** — what
+was done and **why**, newest at the bottom, never corrected in place. Write it
+as the last act of the session, not the first act of the next one.
+
+The journal is the history of executing the build. Code says what the system
+does now; the journal says what it used to do, what it cost to change, and
+which beliefs turned out to be wrong. Nearly everything expensive to rediscover
+lives there and nowhere else.
+
+An entry is headed with the date, a short title, and where it landed:
+
+```markdown
+## 2026-09-04 — Both runway stages render their final frame without JS (#51, `ce46ae0`)
+```
+
+Then prose — not a bullet list of file names, which the diff already tells you.
+What to put in, in rough order of value:
+
+- **Why, over what.** The reason a thing was done survives; the diff does not
+  need restating.
+- **Measured numbers, exactly.** "The comp's open mask is 2696×2352 on an 860px
+  band — 2.735× the band's height, so a 390×664 phone needs ~534%" is worth
+  keeping. "Fixed the hero on mobile" is not.
+- **Defects, named.** What broke, what it looked like, and what made it
+  invisible until it wasn't.
+- **What was tried and abandoned**, and what it would take to revive it. A dead
+  end nobody wrote down gets walked twice.
+- **Beliefs corrected on contact.** The design assumption that turned out false
+  is usually the most valuable line in the entry.
+- **Honest accounting.** If a win came from somewhere other than the change
+  that claimed it, say so — that is exactly what someone will otherwise
+  over-invest in next.
+
+**History is never edited to be right.** An entry that stops being true is not
+rewritten; a later entry corrects it, and says which one it corrects. The
+journal is a record of what was believed at the time, and that record is most
+useful precisely where it was wrong. Fixing the past in place destroys the only
+evidence of how the mistake was made.
+
+If a session produced nothing worth an entry, that is itself worth one line.

--- a/docs/workJournal.md
+++ b/docs/workJournal.md
@@ -1,0 +1,55 @@
+# Caltex Medical — Work Journal
+
+Running log of build work: what was done, why, and where it landed.
+Chronological — newest entry at the bottom. The code says what the site does
+now; this is the history of getting it there.
+
+The convention is in [CLAUDE.md](../CLAUDE.md) under "The work journal". In
+short: every working session appends a dated entry, prose over bullets, why
+over what, and history is never edited to be right — a later entry corrects an
+earlier one and says so.
+
+---
+
+## 2026-09-05 — Journal opened, and 138 commits of history summarised rather than reconstructed (`chore/work-journal`)
+
+The journal starts today, so this first entry is a **backfill**: a deliberately
+coarse summary written from the commit log, not from memory. Detail below this
+line is trustworthy; detail above it is not, and nothing here should be cited
+as though someone wrote it down at the time. For anything before 2026-09-05 the
+commit log is the record.
+
+**What this repo is.** The marketing site for Caltex Medical — AEDs, leasing
+and program management for the San Antonio area and the Texas Hill Country.
+SvelteKit 2 / Svelte 5 / Tailwind v4 / Prismic, deployed on Netlify at
+`https://www.caltexmedical.com`. Five hand-built routes (home, community,
+leasing, purchases, contact) plus a Prismic `[uid]` catch-all, four slices
+(`Hero`, `ContentWidth`, `RichText`, `ThreeStepPlan`), and no form backend
+anywhere: the "request info" modal is a `mailto:`/`tel:` card, and the dead
+Netlify-Forms remnants were removed deliberately in #19.
+
+**The eras.** 138 commits fall into two clearly separate lives. **2025-01
+through 2025-09 (42 commits)** is the build and the client rounds — terse
+messages ("first push for desktop", "markup", "client changes", "mobile
+tweaks"), heaviest in January and February, then content and responsive passes
+in July and August, then nothing for eight months. **2026-05 through 2026-09
+(94 commits)** is almost entirely fleet maintenance rather than feature work:
+pnpm, onboarding onto `@reddoorla/maintenance` and its synced configs, the
+Svelte 4→5 and Tailwind 3→4 migration finished off (May alone is 46 commits —
+see [UPGRADE_NOTES.md](UPGRADE_NOTES.md)), `adapter-auto` → `adapter-netlify`,
+Node 24, the shared reusable CI workflow, Renovate auto-merge, and a purge of
+19 unused components. Layered on top of that is a run of small correctness
+fixes that are worth knowing happened: `og:image` (#28), `/health` (#29), a
+smoke suite (#30), 404 instead of 500 for unknown pages (#31), a
+Prismic-backed `sitemap.xml` (#34), an honest meta-description fallback (#37),
+distinct per-page titles (#51), and capped Prismic srcset widths with a real
+`sizes` on every image (#59).
+
+**The one content defect in the log is worth pulling forward.** `4a80b2a`
+corrects the client's own name — "Ryan Kohen" → "Ryan Kohnen" — which had been
+hand-copied wrong across five files. That is why `src/lib/constants/contact.ts`
+exists and why contact details are imported from it rather than typed again.
+
+**State as of this entry.** `main` at `a1b7315`, tree clean, nothing in flight
+and no work in progress on any local branch. Last substantive change was
+2026-09-01.


### PR DESCRIPTION
Adds `docs/workJournal.md` and a `CLAUDE.md` carrying the fleet-wide **The work journal** rule: every working session appends a dated entry to the journal — what was done and **why**, newest at the bottom, prose over bullets, and history is never edited to be right (a later entry corrects an earlier one and says so).

The point is that the expensive knowledge — measured numbers, defects and what made them invisible, dead ends, beliefs corrected on contact — currently lives only in commit messages and PR bodies, where it is real but unordered.

The first entry is a **backfill**, written from the commit log rather than from memory, and says so explicitly. It summarises the two eras this repo has had — the 2025 build and client rounds, then the 2026 fleet-maintenance run (pnpm, Svelte 5, the shared CI workflow, and a string of small SEO/correctness fixes) — and records the current state.

`CLAUDE.md` did not exist here before, so it also carries the short list of things an agent working in this repo genuinely needs: the check commands (there is no `pnpm verify` here), the configs owned by `@reddoorla/maintenance` that `sync-configs` will overwrite, that `README.md` still describes the wireframer starter this was forked from, and that public contact details belong in `src/lib/constants/contact.ts`.

Docs only — no code, config or build change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)